### PR TITLE
feat: 正式なアプリ名を表示

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,7 +1,7 @@
 <header class="bg-white shadow-md fixed top-0 left-0 right-0 z-50">
   <nav class="container mx-auto px-4 py-4">
     <div class="flex items-center justify-between">
-      <%= link_to "アプリ名", root_path, class: "text-xl font-bold text-gray-800" %>
+      <%= link_to "ChoiUp", root_path, class: "text-xl font-bold text-gray-800" %>
       
       <ul class="flex items-center space-x-6">
         <% if user_signed_in? %>


### PR DESCRIPTION
## 概要
ヘッダーにアプリケーション名「ChoiUp」を表示

## やったこと
- ヘッダー部分のアプリ名を「アプリ名」から「ChoiUp」に変更
- アプリ名をクリックするとトップページに遷移するリンクを実装

## 変更結果
- ヘッダー左上に「ChoiUp」が表示される
- クリックすると `/` (トップページ)に遷移する
- 全ページで統一して表示される

## どうやるのか
### 確認手順
1. `docker comopse up` でサーバーを起動
2. ブラウザで `http://localhost:3000` にアクセス
3. ヘッダー左上に「ChoiUp」が表示されることを確認
4. 「ChoiUp」をクリックしてトップページに遷移することを確認
5. 他のページ(例: `/materials/new`)でも同様に表示されることを確認

## 備考
- `app/views/shared/_header.html.erb` のみ変更
- Tailwind CSSのクラスを使用してスタイリング済み

close #132 