### PR TITLE
feat: 教材登録ページへのリンクを教材一覧ページに追加

### DIFF
--- a/app/views/materials/index.html.erb
+++ b/app/views/materials/index.html.erb
@@ -17,20 +17,25 @@
   <!-- 検索結果のヘッダー -->
   <div class="mb-6">
     <% if @search_keyword.present? %>
-      <h1 class="text-2xl font-bold text-gray-800 mb-2">
+      <h1 class="text-2xl font-bold text-gray-300 mb-2">
         "<%= @search_keyword %>" の検索結果
       </h1>
-      <p class="text-gray-600">
+      <p class="text-gray-500">
         <%= @materials.count %>件の教材が見つかりました
       </p>
     <% else %>
-      <h1 class="text-2xl font-bold text-gray-800 mb-2">
+      <h1 class="text-2xl font-bold text-gray-300 mb-2">
         教材一覧
       </h1>
-      <p class="text-gray-600">
+      <p class="text-gray-500">
         全 <%= @materials.count %>件の教材
       </p>
     <% end %>
+  </div>
+
+  <div class="flex justify-end mb-6">
+    <%= link_to "新規教材を登録", new_material_path,
+        class: "px-6 py-3 bg-blue-500 text-white font-semibold rounded-lg hover:bg-blue-600 transition shadow-md whitespace-nowrap" %>
   </div>
 
   <!-- 検索結果の表示 -->


### PR DESCRIPTION

## 概要

教材一覧ページに「新規教材を登録」ボタン(link_to)を追加し、ユーザーが教材登録画面へ簡単にアクセスできるようにしました。

## やったこと

- 教材一覧ページ（`app/views/materials/index.html.erb`）に「新規教材を登録」ボタンを追加
- ログアウトしているユーザーもボタンが表示されるように実装
- Tailwind CSSを使用したボタンのスタイリング

## 変更結果

### ログイン時

検索フォーム右下に「新規教材を登録」ボタンが表示される
教材のパーシャルより上で

### 未ログイン時

検索フォーム右下に「新規教材を登録」ボタンが表示される
教材のパーシャルより上で

### ボタンクリック後

新規教材登録画面（`/materials/new`）へ遷移

## やらないこと

- 新規教材登録画面自体のUI改善


## どうやるのか

### 動作確認手順

**正常系**

1. ログイン状態で `/materials` にアクセス
2. 検索フォーム下に「新規教材を登録」ボタンが表示されることを確認
3. ボタンをクリックし、`/materials/new` へ遷移することを確認

**異常系**

1. ログアウト状態で `/materials` にアクセス
2. 「新規教材を登録」ボタンが **表示され、押すとログインページにリダイレクトされる** ことを確認
3. 直接 `/materials/new` にアクセスし、ログイン画面にリダイレクトされることを確認（`authenticate_user!` の動作確認）

## 課題

特になし

## 備考

- ルーティング（`new_material_path`）とコントローラーの認証処理（`authenticate_user!`）は既に実装済みのため、ビューへのボタン追加のみで対応完了
- ボタンの配置位置は、教材のパーシャルの部分の右下も検討しているが、あまりよくないかもしれません。

close #129 