### PR TITLE
feat: 教材詳細ページに一覧ページへ戻るリンクを追加

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.21.1)
       msgpack (~> 1.2)
-    brakeman (8.0.2)
+    brakeman (8.0.4)
       racc
     builder (3.3.0)
     capybara (3.40.0)
@@ -389,7 +389,7 @@ CHECKSUMS
   bigdecimal (4.0.1) sha256=8b07d3d065a9f921c80ceaea7c9d4ae596697295b584c296fe599dd0ad01c4a7
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
   bootsnap (1.21.1) sha256=9373acfe732da35846623c337d3481af8ce77c7b3a927fb50e9aa92b46dbc4c4
-  brakeman (8.0.2) sha256=7b02065ce8b1de93949cefd3f2ad78e8eb370e644b95c8556a32a912a782426a
+  brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
   cgi (0.5.1) sha256=e93fcafc69b8a934fe1e6146121fa35430efa8b4a4047c4893764067036f18e9

--- a/app/views/materials/show.html.erb
+++ b/app/views/materials/show.html.erb
@@ -55,4 +55,10 @@
       <%= render 'reviews/list', reviews: @reviews %>
     </div>
   </div>
+
+  <!-- 一覧に戻る -->
+  <div class="mt-8">
+    <%= link_to "一覧に戻る", materials_path,
+                class: "inline-flex items-center px-6 py-3 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 transition-colors" %>
+  </div>
 </div>


### PR DESCRIPTION
  ## 概要
  教材詳細ページ（materials#show）に、教材一覧ページ（materials#index）へ戻るリンクを追加しました。

  ## 背景・目的
  - 詳細ページから一覧に戻る手段がブラウザの戻るボタンしかなく、明示的な導線が不足していた
  - 直感的なナビゲーションを提供し UX を改善する
                                                                                                                                                                                                                                                                                                      
  ## 変更内容
  - `app/views/materials/show.html.erb` の末尾に「一覧に戻る」リンクを追加
  - スタイルは `materials/new.html.erb` のキャンセルボタンと統一（Tailwind の gray-200 系）
  - ルーティング変更なし（既存の `materials_path` を利用）

  ## 動作確認
  - [x] 詳細ページ末尾に「一覧に戻る」ボタンが表示される
  - [x] クリックで `/materials` に遷移する
  - [x] ホバー時に背景色が変化する（gray-200 → gray-300）

  ## 関連 issue
  Closes #130 
  
  ## 追記
brakemanのversionをあげました。