### PR TITLE
Feat/setup ci with GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,9 @@ jobs:
           RAILS_ENV: test
           DATABASE_URL: postgres://postgres:postgres@localhost:5432
           # REDIS_URL: redis://localhost:6379/0
-        run: bin/rails db:test:prepare test test:system
+        run: |
+          bin/rails db:test:prepare
+          bundle exec rspec
 
       - name: Keep screenshots from failed system tests
         uses: actions/upload-artifact@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@
 docker compose up
 ```
 
-`web` コンテナ起動時に `bundle install → yarn install → rails db:prepare → bin/dev`（JS/CSS ウォッチャー込み）が自動実行される。アプリは http://localhost:3000 で起動。
+`web` コンテナ起動時に `bundle install → yarn install → rails db:prepare → tmp/pids/server.pid 削除 → bin/dev`（JS/CSS ウォッチャー込み）が自動実行される。`tmp/pids/server.pid` の削除はコンテナ再起動時の起動失敗を防ぐため。アプリは http://localhost:3000 で起動。
 
 ### コンテナ内でのコマンド実行
 
@@ -29,6 +29,7 @@ docker compose exec web bundle exec brakeman                   # セキュリテ
 
 ### Docker 構成メモ
 
+- docker compose の構成ファイル: `compose.yml`（`docker-compose.yml` ではない）
 - `Dockerfile.dev`: Ruby 3.3.6 ベース、Node 20 + Yarn をインストール
 - ソースコードは `.:/app` でマウント（ホストの変更がリアルタイムに反映）
 - Gem は `bundle_data` volume にキャッシュ（コンテナ再起動時の再インストール不要）
@@ -58,11 +59,11 @@ resources :profiles
 
 - TailwindCSS + DaisyUI でスタイリング
 - Hotwire（Turbo + Stimulus）を使用。esbuild でバンドル
-- CSS は `rails-tailwindcss` gem でビルド（`bin/dev` 起動時にウォッチ）
+- CSS は `tailwindcss-rails` gem でビルド（`bin/dev` 起動時にウォッチ）
 
 ### CI（`.github/workflows/ci.yml`）
 
-2 ジョブが並列実行：brakeman セキュリティスキャン、rubocop Lint。
+3 ジョブが並列実行：brakeman セキュリティスキャン（`scan_ruby`）、rubocop Lint（`lint`）、RSpec 実行（`test`）。
 
 ## 技術スタック
 


### PR DESCRIPTION

## 概要

RSpec への移行は完了していたものの、`.github/workflows/ci.yml` の `test` ジョブは Minitest 用の`bin/rails db:test:prepare test test:system` のままだった。
CI の実行コマンドを RSpec 用に切り替えて、RSpecに切り替える。

また、付随作業として CLAUDE.md に含まれていた古い記述・不正確な記述を
現状に合わせて修正する。

## 変更内容

### CI（メインの変更）
- `.github/workflows/ci.yml` の `test` ジョブの `Run tests` ステップを
  `bin/rails db:test:prepare test test:system` から
  `bin/rails db:test:prepare` と `bundle exec rspec` の 2 ステップに変更
- `services.postgres` / Chrome install / screenshots upload などの既存ステップはsystem spec 追加時にそのまま流用できるよう現状維持

### CLAUDE.md（付随更新）
- Docker 構成メモに `compose.yml`（`docker-compose.yml` ではない）を明記
- CI セクションを最新化：2 ジョブ → 3 ジョブ（RSpec 実行を含む）
- フロントエンド gem 名を訂正：`rails-tailwindcss` → `tailwindcss-rails`
- 開発サーバー起動フローに `tmp/pids/server.pid` 削除ステップを追記

## 影響範囲

- GitHub Actions の `test` ジョブのみ（`scan_ruby` / `lint` ジョブは変更なし）
- アプリケーションコード・DB スキーマ・画面への影響は無し
- CLAUDE.md は LLM への指示のみ。人間の開発者向けにも情報が正確になる

## 確認方法

1. この PR 作成後、GitHub Actions で `test` ジョブが走ることを確認
2. `test` ジョブのログで以下を確認：
   - `bin/rails db:test:prepare` が成功
   - `bundle exec rspec` が `3 examples, 0 failures` で完了
3. `scan_ruby`（brakeman）/ `lint`（rubocop）ジョブも従来通り成功することを確認

## スクリーンショット

該当なし（CI 設定と CLAUDE.md の変更のため UI 変更は無し）

## 補足事項

- `test/` 配下にはテストファイルが無いため、Minitest 実行を外しても実害なし
- system spec は現時点で未整備。Chrome install と screenshots upload のステップは「将来書く可能性あり」という判断で意図的に残している。不要になった時点で別 PR で削除可

## 関連 Issue

close #172 
