### PR TITLE
test: User モデルのユニットテストを拡充

### DIFF
--- a/spec/factories/materials.rb
+++ b/spec/factories/materials.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :material do
+    sequence(:title) { |n| "教材#{n}" }
+    sequence(:url) { |n| "https://example.com/material/#{n}" }
+    description { "教材の説明" }
+  end
+end

--- a/spec/factories/reviews.rb
+++ b/spec/factories/reviews.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :review do
+    user
+    material
+    start_level { :complete_beginner }
+    difficulty_rating { :just_right }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,12 @@
 require "rails_helper"
 
 RSpec.describe User, type: :model do
+  describe "ファクトリ" do
+    it "デフォルトで valid なオブジェクトを生成する" do
+      expect(build(:user)).to be_valid
+    end
+  end
+
   describe "display_name" do
     it "50 文字ちょうどなら valid（境界値・正常系）" do
       user = build(:user, display_name: "あ" * 50)
@@ -15,6 +21,34 @@ RSpec.describe User, type: :model do
     it "nil だと invalid（presence 違反・異常系）" do
       user = build(:user, display_name: nil)
       expect(user).not_to be_valid
+    end
+
+    it "空文字だと invalid（presence 違反・異常系）" do
+      user = build(:user, display_name: "")
+      expect(user).not_to be_valid
+    end
+  end
+
+  describe "アソシエーション" do
+    describe "has_many :reviews" do
+      # reflect_on_association は関連定義の情報オブジェクトを返す。
+      # .macro で関連種別、.options で has_many に渡したオプションを取得できる。
+      it "関連が has_many として定義されている" do
+        association = User.reflect_on_association(:reviews)
+        expect(association.macro).to eq :has_many
+      end
+
+      it "dependent: :destroy が指定されている" do
+        association = User.reflect_on_association(:reviews)
+        expect(association.options[:dependent]).to eq :destroy
+      end
+
+      it "User を destroy すると関連する Review も削除される（挙動）" do
+        user = create(:user)
+        create(:review, user: user)
+        create(:review, user: user)
+        expect { user.destroy }.to change { Review.count }.by(-2)
+      end
     end
   end
 end


### PR DESCRIPTION
## 概要
User モデルのユニットテストが display_name の 3 example のみだったため、カバレッジを広げる目的で拡充する。

## 変更内容
- ファクトリ健全性チェック（`build(:user)` が valid であること）の example を追加
- `display_name` の境界値ケースに空文字を追加（既存の nil とは別経路の presence 検証）
- `has_many :reviews` の関連定義を `reflect_on_association` で静的検証（macro / dependent オプション）
- `User#destroy` 時に関連 `Review` が削除される挙動を実 destroy で検証
- 上記の関連テストに必要な `spec/factories/reviews.rb` / `spec/factories/materials.rb` を新規作成

## 影響範囲
- テストコードのみ。`app/` 配下のプロダクションコードに変更なし
- CI（`test` ジョブ）が走る spec が 3 → 8 examples に増える

## 確認方法
1. ブランチを checkout する
2. `docker compose exec web bundle exec rspec spec/models/user_spec.rb` を実行
3. `8 examples, 0 failures` が出力されることを確認
4. CI 上でも `test` ジョブが緑になることを確認

## スクリーンショット
N/A（テストコードのみのため）

## 補足事項
特になし

## 関連Issue
close #170 
