### PR TITLE
fix: Review の enum DEPRECATION 警告を解消

### DIFF
--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -3,21 +3,21 @@ class Review < ApplicationRecord
   belongs_to :material
 
   # enumの定義
-  enum start_level: {
+  enum :start_level, {
     complete_beginner: 1,  # 全くの初心者
     entry_level: 2,        # 入門レベル
     basic_level: 3,        # 基礎レベル
     intermediate_level: 4, # 中級レベル
     advanced_level: 5      # 上級レベル
-  }, _prefix: true
+  }, prefix: true
 
-  enum difficulty_rating: {
+  enum :difficulty_rating, {
     very_easy: 1,      # とても優しい
     easy: 2,           # 優しい
     just_right: 3,     # ちょうどいい
     difficult: 4,      # 難しい
     very_difficult: 5  # とても難しい
-  }, _prefix: true
+  }, prefix: true
 
   # バリデーション
   validates :start_level, presence: true


### PR DESCRIPTION
## 概要
`bundle exec rspec` 実行時に Review モデルの enum 定義で Rails 8.0 向けの DEPRECATION 警告が 2 件出ていた。

## 変更内容
- `app/models/review.rb` の `enum start_level: {...}, _prefix: true` を `enum :start_level, {...}, prefix: true` に書き換え
- `app/models/review.rb` の `enum difficulty_rating: {...}, _prefix: true` を `enum :difficulty_rating, {...}, prefix: true` に書き換え
- `_prefix:` から `prefix:`（アンダースコアなし）へオプション名をリネーム

## 影響範囲
- `app/models/review.rb` のみ。
- enum 値（シンボル名）と integer 値は不変のため、以下はすべて影響なし：
  - `Review.start_levels` / `Review.difficulty_ratings` クラスメソッド
  - `review.start_level` / `review.difficulty_rating` 属性アクセサ
  - I18n キー（`activerecord.enums.review.start_level.*` 等）

## 確認方法
1. `docker compose exec web bundle exec rspec` を実行し、`8 examples, 0 failures` と表示され、DEPRECATION WARNING が出ないことを確認
2. `docker compose up` で開発サーバーを起動し、http://localhost:3000/materials/1などに にアクセス
3. レビュー投稿フォームでラジオボタンが「学習開始時のレベル」「体感難易度」それぞれ 5 件ずつ表示されること
4. 既存レビューが日本語表記（例：「全くの初心者」「ちょうどいい」）で正しく表示されること

## スクリーンショット
N/A（モデル層の構文変更のみで UI への変更なし）

## 補足事項
- `prefix: true` は維持。`review.start_level_complete_beginner?` のような述語メソッドは現状未使用だが、将来使う可能性に備えて互換性を保つ

## 関連Issue
Closes #208 