### PR TITLE
Test/add material specs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
           # REDIS_URL: redis://localhost:6379/0
         run: |
           bin/rails db:test:prepare
+          bin/rails tailwindcss:build
           bundle exec rspec
 
       - name: Keep screenshots from failed system tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,15 @@ jobs:
           ruby-version: .ruby-version
           bundler-cache: true
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Install JS dependencies
+        run: yarn install --frozen-lockfile
+
       - name: Run tests
         env:
           RAILS_ENV: test
@@ -76,7 +85,7 @@ jobs:
           # REDIS_URL: redis://localhost:6379/0
         run: |
           bin/rails db:test:prepare
-          bin/rails tailwindcss:build
+          bin/rails assets:precompile
           bundle exec rspec
 
       - name: Keep screenshots from failed system tests

--- a/spec/models/material_spec.rb
+++ b/spec/models/material_spec.rb
@@ -1,0 +1,132 @@
+require "rails_helper"
+
+RSpec.describe Material, type: :model do
+  describe "ファクトリ" do
+    it "デフォルトで valid なオブジェクトを生成する" do
+      expect(build(:material)).to be_valid
+    end
+  end
+
+  describe "title" do
+    it "1 文字で valid（下限・正常系）" do
+      material = build(:material, title: "あ")
+      expect(material).to be_valid
+    end
+
+    it "100 文字ちょうどで valid（境界値・正常系）" do
+      material = build(:material, title: "あ" * 100)
+      expect(material).to be_valid
+    end
+
+    it "101 文字で invalid（境界値超え・異常系）" do
+      material = build(:material, title: "あ" * 101)
+      expect(material).not_to be_valid
+    end
+
+    it "nil で invalid（presence 違反・異常系）" do
+      material = build(:material, title: nil)
+      expect(material).not_to be_valid
+    end
+
+    it "空文字で invalid（presence 違反・異常系）" do
+      material = build(:material, title: "")
+      expect(material).not_to be_valid
+    end
+  end
+
+  describe "url" do
+    it "http スキームで valid（正常系）" do
+      material = build(:material, url: "http://example.com")
+      expect(material).to be_valid
+    end
+
+    it "https スキーム + path + query で valid（正常系）" do
+      material = build(:material, url: "https://example.com/path?q=1")
+      expect(material).to be_valid
+    end
+
+    it "nil で invalid（presence 違反・異常系）" do
+      material = build(:material, url: nil)
+      expect(material).not_to be_valid
+    end
+
+    it "空文字で invalid（presence 違反・異常系）" do
+      material = build(:material, url: "")
+      expect(material).not_to be_valid
+    end
+
+    it "ftp スキームで invalid（カスタム検証・異常系）" do
+      material = build(:material, url: "ftp://example.com")
+      material.valid?
+      expect(material.errors[:url]).to include(a_string_including("httpまたはhttps"))
+    end
+
+    it "URL 形式でない文字列で invalid（format 違反・異常系）" do
+      material = build(:material, url: "not a url")
+      expect(material).not_to be_valid
+    end
+  end
+
+  describe "description" do
+    it "nil で valid（allow_blank・正常系）" do
+      material = build(:material, description: nil)
+      expect(material).to be_valid
+    end
+
+    it "空文字で valid（allow_blank・正常系）" do
+      material = build(:material, description: "")
+      expect(material).to be_valid
+    end
+
+    it "5000 文字ちょうどで valid（境界値・正常系）" do
+      material = build(:material, description: "あ" * 5000)
+      expect(material).to be_valid
+    end
+
+    it "5001 文字で invalid（境界値超え・異常系）" do
+      material = build(:material, description: "あ" * 5001)
+      expect(material).not_to be_valid
+    end
+  end
+
+  describe "アソシエーション" do
+    describe "has_many :reviews" do
+      it "関連が has_many として定義されている" do
+        association = Material.reflect_on_association(:reviews)
+        expect(association.macro).to eq :has_many
+      end
+
+      it "dependent: :destroy が指定されている" do
+        association = Material.reflect_on_association(:reviews)
+        expect(association.options[:dependent]).to eq :destroy
+      end
+
+      it "Material を destroy すると関連する Review も削除される（挙動）" do
+        material = create(:material)
+        create(:review, material: material)
+        create(:review, material: material)
+        expect { material.destroy }.to change { Review.count }.by(-2)
+      end
+    end
+  end
+
+  describe "Ransack 設定" do
+    it "ransackable_attributes は title のみを返す" do
+      expect(Material.ransackable_attributes).to eq [ "title" ]
+    end
+
+    it "title_cont で部分一致検索ができる（正常系）" do
+      hit = create(:material, title: "Ruby 入門")
+      create(:material, title: "Python 入門")
+      result = Material.ransack(title_cont: "Ruby").result
+      expect(result).to contain_exactly(hit)
+    end
+
+    it "許可されていない属性（description_cont）で検索すると Ransack が例外を投げる" do
+      # description は許可属性ではないため、検索条件として作用せず例外で弾かれる
+      expect {
+        Material.ransack(description_cont: "Ruby").result.load
+      }.to raise_error(RuntimeError, /ransackable/)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -70,4 +70,5 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.include FactoryBot::Syntax::Methods
+  config.include Devise::Test::IntegrationHelpers, type: :request
 end

--- a/spec/requests/materials_spec.rb
+++ b/spec/requests/materials_spec.rb
@@ -1,0 +1,133 @@
+require "rails_helper"
+
+RSpec.describe "Materials", type: :request do
+  describe "GET /materials" do
+    it "未ログインでも 200 を返す（正常系）" do
+      get materials_path
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "登録済みの教材が body に含まれる（正常系）" do
+      create(:material, title: "Ruby 入門")
+      create(:material, title: "Python 入門")
+      get materials_path
+      expect(response.body).to include("Ruby 入門")
+      expect(response.body).to include("Python 入門")
+    end
+
+    it "?q[title_cont] で絞り込みが効く（正常系）" do
+      create(:material, title: "Ruby 入門")
+      create(:material, title: "Python 入門")
+      get materials_path, params: { q: { title_cont: "Ruby" } }
+      expect(response.body).to include("Ruby 入門")
+      expect(response.body).not_to include("Python 入門")
+    end
+  end
+
+  describe "GET /materials/:id" do
+    let(:material) { create(:material, title: "Rails ガイド", description: "詳しい解説", url: "https://example.com/rails") }
+
+    it "未ログインでも 200 を返す（正常系）" do
+      get material_path(material)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "title / description / URL が body に含まれる（正常系）" do
+      get material_path(material)
+      expect(response.body).to include("Rails ガイド")
+      expect(response.body).to include("詳しい解説")
+      expect(response.body).to include("https://example.com/rails")
+    end
+
+    it "存在しない id だと 404 を返す（異常系）" do
+      # Rails 7.1+ は test 環境でも RecordNotFound を rescue して 404 レスポンスに変換する
+      nonexistent_id = Material.maximum(:id).to_i + 1
+      get material_path(id: nonexistent_id)
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "GET /materials/new" do
+    context "未ログイン" do
+      it "ログイン画面にリダイレクトする（認可・異常系）" do
+        get new_material_path
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "ログイン済み" do
+      it "200 を返す（正常系）" do
+        sign_in create(:user)
+        get new_material_path
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
+  describe "POST /materials" do
+    let(:valid_params) do
+      { material: { title: "新教材", url: "https://example.com/new", description: "説明" } }
+    end
+    let(:invalid_params) do
+      { material: { title: "", url: "https://example.com/new", description: "説明" } }
+    end
+
+    context "未ログイン" do
+      it "Material が作成されない（認可・異常系）" do
+        expect {
+          post materials_path, params: valid_params
+        }.not_to change(Material, :count)
+      end
+
+      it "ログイン画面にリダイレクトする" do
+        post materials_path, params: valid_params
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "ログイン済み + 正常パラメータ" do
+      before { sign_in create(:user) }
+
+      it "Material が 1 件増える" do
+        expect {
+          post materials_path, params: valid_params
+        }.to change(Material, :count).by(1)
+      end
+
+      it "root_path にリダイレクトし、notice flash が立つ" do
+        post materials_path, params: valid_params
+        expect(response).to redirect_to(root_path)
+        expect(flash[:notice]).to include("教材を登録しました")
+      end
+    end
+
+    context "ログイン済み + 不正パラメータ" do
+      before { sign_in create(:user) }
+
+      it "Material が増えない（異常系）" do
+        expect {
+          post materials_path, params: invalid_params
+        }.not_to change(Material, :count)
+      end
+
+      it "422 を返し、エラー表示用 flash がレンダリングされる" do
+        post materials_path, params: invalid_params
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.body).to include("教材の登録に失敗しました")
+      end
+    end
+
+    context "Strong Parameters" do
+      before { sign_in create(:user) }
+
+      it "許可外の属性（id 指定など）は無視される" do
+        # 許可外属性として id を指定しても、AR が新規作成時にこれを採用しない（permit 漏れ）ことを確認
+        injected_id = Material.maximum(:id).to_i + 1
+        post materials_path, params: {
+          material: valid_params[:material].merge(id: injected_id)
+        }
+        expect(Material.find_by(id: injected_id)).to be_nil
+      end
+    end
+  end
+end

--- a/spec/requests/materials_spec.rb
+++ b/spec/requests/materials_spec.rb
@@ -112,7 +112,8 @@ RSpec.describe "Materials", type: :request do
 
       it "422 を返し、エラー表示用 flash がレンダリングされる" do
         post materials_path, params: invalid_params
-        expect(response).to have_http_status(:unprocessable_entity)
+        # Rack 3.x で :unprocessable_entity は deprecated、:unprocessable_content に改名
+        expect(response).to have_http_status(:unprocessable_content)
         expect(response.body).to include("教材の登録に失敗しました")
       end
     end


### PR DESCRIPTION
## 概要
Material モデル と MaterialsController に対するユニットテストが不在だったため、テストを追加する。
画面が今後変更される可能性があるため system test / E2E は対象外とし、モデル spec と request spec のみを整備する。

## 変更内容
- `spec/models/material_spec.rb` を新規追加（バリデーション・アソシエーション・Ransack 設定の検証）
- `spec/requests/materials_spec.rb` を新規追加
- `spec/rails_helper.rb` に `Devise::Test::IntegrationHelpers` の include を追加し、request spec で `sign_in` を使えるようにした

## 影響範囲
- アプリケーション本体（`app/`）への変更はないため、機能影響はなし
- `spec/rails_helper.rb` の include 追加は request spec のみ対象（`type: :request`）で他の spec タイプには影響しない
- CI（`.github/workflows/ci.yml`）の RSpec ジョブで新規 spec が実行される

## 確認方法
1. `docker compose up -d` で開発環境を起動
2. `docker compose exec web bundle exec rspec` で全体（既存分含めて 45 件）が緑になることを確認


## スクリーンショット
なし（テスト追加のみ）

## 補足事項
- Ransack 4.x は許可属性外の検索条件で `RuntimeError` を投げるため、`description_cont` 検索のテストはこの例外を期待する形で書いている。将来 `Material.ransackable_attributes` を広げる際はこのテストの見直しが必要。
- request spec の追加に伴い、CI 上で layout の `stylesheet_link_tag "tailwind"` が `tailwind.css` を要求してテスト失敗となったため、CI ワークフローに `bin/rails tailwindcss:build` の実行を追加した。

## 関連Issue
close #171 