### PR TITLE
test: Review モデルとリクエストのユニットテストを追加

### DIFF
--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -1,0 +1,94 @@
+require "rails_helper"
+
+RSpec.describe Review, type: :model do
+  describe "ファクトリ" do
+    it "デフォルトで valid なオブジェクトを生成する" do
+      expect(build(:review)).to be_valid
+    end
+  end
+
+  describe "start_level" do
+    it "nil で invalid（presence 違反・異常系）" do
+      review = build(:review, start_level: nil)
+      expect(review).not_to be_valid
+    end
+
+    it "想定の 5 段階が enum として定義されている" do
+      expect(Review.start_levels.keys).to contain_exactly(
+        "complete_beginner", "entry_level", "basic_level",
+        "intermediate_level", "advanced_level"
+      )
+    end
+
+    it "範囲外の値を代入すると ArgumentError（enum 違反・異常系）" do
+      review = build(:review)
+      expect { review.start_level = "unknown_level" }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "difficulty_rating" do
+    it "nil で invalid（presence 違反・異常系）" do
+      review = build(:review, difficulty_rating: nil)
+      expect(review).not_to be_valid
+    end
+
+    it "想定の 5 段階が enum として定義されている" do
+      expect(Review.difficulty_ratings.keys).to contain_exactly(
+        "very_easy", "easy", "just_right", "difficult", "very_difficult"
+      )
+    end
+
+    it "範囲外の値を代入すると ArgumentError（enum 違反・異常系）" do
+      review = build(:review)
+      expect { review.difficulty_rating = "extreme" }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "comment" do
+    it "nil で valid（任意項目・正常系）" do
+      review = build(:review, comment: nil)
+      expect(review).to be_valid
+    end
+
+    it "空文字で valid（任意項目・正常系）" do
+      review = build(:review, comment: "")
+      expect(review).to be_valid
+    end
+  end
+
+  describe "アソシエーション" do
+    it "user が nil で invalid（belongs_to required・異常系）" do
+      review = build(:review, user: nil)
+      expect(review).not_to be_valid
+    end
+
+    it "material が nil で invalid（belongs_to required・異常系）" do
+      review = build(:review, material: nil)
+      expect(review).not_to be_valid
+    end
+  end
+
+  describe "一意性制約（user_id と material_id の組み合わせ）" do
+    let(:user) { create(:user) }
+    let(:material) { create(:material) }
+
+    it "同一 user と 同一 material の 2 件目は invalid（異常系）" do
+      create(:review, user: user, material: material)
+      review_with_same_user_and_material = build(:review, user: user, material: material)
+      expect(review_with_same_user_and_material).not_to be_valid
+      expect(review_with_same_user_and_material.errors[:user_id]).to include(a_string_including("同じ教材に対して1回のみ評価できます"))
+    end
+
+    it "同一 user でも material が異なれば valid（正常系）" do
+      create(:review, user: user, material: material)
+      review_with_different_material = build(:review, user: user, material: create(:material))
+      expect(review_with_different_material).to be_valid
+    end
+
+    it "同一 material でも user が異なれば valid（正常系）" do
+      create(:review, user: user, material: material)
+      review_with_different_user = build(:review, user: create(:user), material: material)
+      expect(review_with_different_user).to be_valid
+    end
+  end
+end

--- a/spec/requests/reviews_spec.rb
+++ b/spec/requests/reviews_spec.rb
@@ -1,0 +1,119 @@
+require "rails_helper"
+
+RSpec.describe "Reviews", type: :request do
+  let(:material) { create(:material) }
+  let(:user) { create(:user) }
+  let(:valid_params) do
+    {
+      review: {
+        start_level: "complete_beginner",
+        difficulty_rating: "just_right",
+        comment: "良かった"
+      }
+    }
+  end
+  let(:invalid_params) do
+    {
+      review: {
+        start_level: "",
+        difficulty_rating: "",
+        comment: ""
+      }
+    }
+  end
+
+  describe "POST /materials/:material_id/reviews" do
+    context "未ログイン" do
+      it "Review が作成されない（認可・異常系）" do
+        expect {
+          post material_reviews_path(material), params: valid_params
+        }.not_to change(Review, :count)
+      end
+
+      it "ログイン画面にリダイレクトする" do
+        post material_reviews_path(material), params: valid_params
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "ログイン済み + 正常パラメータ" do
+      before { sign_in user }
+
+      it "Review が 1 件増える" do
+        expect {
+          post material_reviews_path(material), params: valid_params
+        }.to change(Review, :count).by(1)
+      end
+
+      it "material_path にリダイレクトし、notice flash が立つ" do
+        post material_reviews_path(material), params: valid_params
+        expect(response).to redirect_to(material_path(material))
+        expect(flash[:notice]).to include("評価を投稿しました")
+      end
+
+      it "作成された Review の user は current_user、material は URL の material と一致する" do
+        post material_reviews_path(material), params: valid_params
+        review = Review.last
+        expect(review.user).to eq(user)
+        expect(review.material).to eq(material)
+      end
+    end
+
+    context "ログイン済み + 不正パラメータ" do
+      before { sign_in user }
+
+      it "Review が増えない（異常系）" do
+        expect {
+          post material_reviews_path(material), params: invalid_params
+        }.not_to change(Review, :count)
+      end
+
+      it "422 を返し、エラー表示用 flash がレンダリングされる" do
+        post material_reviews_path(material), params: invalid_params
+        # Rack 3.x で :unprocessable_entity は deprecated、:unprocessable_content に改名
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.body).to include("評価の投稿に失敗しました")
+      end
+    end
+
+    context "ログイン済み + 一意性違反（同一 user と 同一 material で 2 回 POST）" do
+      before { sign_in user }
+
+      it "2 回目では Review が増えない（異常系）" do
+        post material_reviews_path(material), params: valid_params
+        expect {
+          post material_reviews_path(material), params: valid_params
+        }.not_to change(Review, :count)
+      end
+
+      it "2 回目は 422 を返し、一意性違反のメッセージが body に含まれる" do
+        post material_reviews_path(material), params: valid_params
+        post material_reviews_path(material), params: valid_params
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.body).to include("同じ教材に対して1回のみ評価できます")
+      end
+    end
+
+    context "存在しない material_id" do
+      before { sign_in user }
+
+      it "404 を返す（異常系）" do
+        nonexistent_id = Material.maximum(:id).to_i + 1
+        post material_reviews_path(material_id: nonexistent_id), params: valid_params
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "Strong Parameters" do
+      before { sign_in user }
+
+      it "review[user_id] に他ユーザー ID を混入させても、保存される user は current_user のまま" do
+        other_user = create(:user)
+        post material_reviews_path(material), params: {
+          review: valid_params[:review].merge(user_id: other_user.id)
+        }
+        expect(Review.last.user).to eq(user)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
Review モデルおよび `POST /materials/:material_id/reviews`（`ReviewsController#create`）に対する RSpec が未整備だったため、Material 側と同じ粒度・スタイルでユニットテスト（モデル仕様 / リクエスト仕様）を追加する。今後 UI が変わる可能性があるため、system spec / E2E は今回スコープ外（将来対応）。

## 変更内容
- `spec/models/review_spec.rb` を新規追加
- `spec/requests/reviews_spec.rb` を新規追加


## 影響範囲
- 追加されるのはテストコードのみ。アプリ本体（`app/` 以下）への影響なし
- CI の `test` ジョブ実行時間がわずかに増加

## 確認方法
1. `docker compose exec web bundle exec rspec spec/models/review_spec.rb spec/requests/reviews_spec.rb` を実行
2. 全てのケースが green になることを確認
3. `docker compose exec web bundle exec rspec` をフルで実行し、リグレッションがないことを確認（手元で 70 examples / 0 failures を確認済み）

## スクリーンショット
なし（テスト追加のみのため）

## 補足事項
- system spec / E2E は今後 UI 変更が見込まれるため対象外。後続 PR で別途対応予定


## 関連Issue
close #179 