### PR TITLE
test: User モデルとサインアップ request の spec を追加

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -29,6 +29,87 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe "email" do
+    it "一般的なメール形式で valid（正常系）" do
+      user = build(:user, email: "valid@example.com")
+      expect(user).to be_valid
+    end
+
+    it "nil で invalid（presence 違反・異常系）" do
+      user = build(:user, email: nil)
+      expect(user).not_to be_valid
+    end
+
+    it "空文字で invalid（presence 違反・異常系）" do
+      user = build(:user, email: "")
+      expect(user).not_to be_valid
+    end
+
+    it "@ を含まない文字列で invalid（format 違反・異常系）" do
+      user = build(:user, email: "not-an-email")
+      expect(user).not_to be_valid
+    end
+
+    it "ローカル部のみで invalid（format 違反・異常系）" do
+      user = build(:user, email: "foo@")
+      expect(user).not_to be_valid
+    end
+
+    it "既存ユーザーと同じ email で invalid（一意性違反・異常系）" do
+      create(:user, email: "dup@example.com")
+      user_with_same_email = build(:user, email: "dup@example.com")
+      expect(user_with_same_email).not_to be_valid
+    end
+
+    it "大文字小文字違いの同 email で invalid（case_insensitive_keys・異常系）" do
+      # Devise の case_insensitive_keys = [:email] により大文字小文字を区別せず一意性を判定する
+      create(:user, email: "case@example.com")
+      user_with_uppercase_email = build(:user, email: "CASE@example.com")
+      expect(user_with_uppercase_email).not_to be_valid
+    end
+  end
+
+  describe "password" do
+    # Devise validatable + config.password_length = 6..128 による境界値
+    it "6 文字ちょうどで valid（境界値・正常系）" do
+      user = build(:user, password: "a" * 6, password_confirmation: "a" * 6)
+      expect(user).to be_valid
+    end
+
+    it "5 文字で invalid（境界値超え・異常系）" do
+      user = build(:user, password: "a" * 5, password_confirmation: "a" * 5)
+      expect(user).not_to be_valid
+    end
+
+    it "128 文字ちょうどで valid（境界値・正常系）" do
+      user = build(:user, password: "a" * 128, password_confirmation: "a" * 128)
+      expect(user).to be_valid
+    end
+
+    it "129 文字で invalid（境界値超え・異常系）" do
+      user = build(:user, password: "a" * 129, password_confirmation: "a" * 129)
+      expect(user).not_to be_valid
+    end
+
+    it "新規作成時に nil だと invalid（presence 違反・異常系）" do
+      user = build(:user, password: nil, password_confirmation: nil)
+      expect(user).not_to be_valid
+    end
+  end
+
+  describe "Devise モジュール構成" do
+    # 認証に関する設定の明文化。誤って外すと auth まわりの挙動が変わるため、構成自体を担保する。
+    it ":database_authenticatable, :registerable, :recoverable, :rememberable, :validatable がすべて有効である" do
+      expect(User.devise_modules).to include(
+        :database_authenticatable,
+        :registerable,
+        :recoverable,
+        :rememberable,
+        :validatable
+      )
+    end
+  end
+
   describe "アソシエーション" do
     describe "has_many :reviews" do
       # reflect_on_association は関連定義の情報オブジェクトを返す。

--- a/spec/requests/users/registrations_spec.rb
+++ b/spec/requests/users/registrations_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+RSpec.describe "Users::Registrations", type: :request do
+  describe "POST /users（サインアップ）" do
+    let(:valid_params) do
+      {
+        user: {
+          email: "newuser@example.com",
+          password: "password123",
+          password_confirmation: "password123",
+          display_name: "新規ユーザー"
+        }
+      }
+    end
+
+    let(:invalid_params) do
+      # display_name は presence 必須のため、空にすればバリデーション失敗
+      {
+        user: {
+          email: "newuser@example.com",
+          password: "password123",
+          password_confirmation: "password123",
+          display_name: ""
+        }
+      }
+    end
+
+    context "正常系: 有効なパラメータ" do
+      it "User が 1 件増える" do
+        expect {
+          post user_registration_path, params: valid_params
+        }.to change(User, :count).by(1)
+      end
+
+      it "root_path にリダイレクトする（after_sign_up_path_for の配線確認）" do
+        post user_registration_path, params: valid_params
+        expect(response).to redirect_to(root_path)
+      end
+
+      it "display_name が保存される（strong parameters の配線確認）" do
+        post user_registration_path, params: valid_params
+        expect(User.last.display_name).to eq "新規ユーザー"
+      end
+
+      it "サインアップ後にログイン状態になる（自動ログインの統合確認）" do
+        # サインアップ後、認証必須ページ（new_material_path）にアクセスして
+        # ログイン画面に飛ばされないことで、ログイン状態を確認する。
+        post user_registration_path, params: valid_params
+        get new_material_path
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "異常系: バリデーション失敗（display_name が空）" do
+      it "User が増えない" do
+        expect {
+          post user_registration_path, params: invalid_params
+        }.not_to change(User, :count)
+      end
+
+      it "ログイン状態にならない" do
+        post user_registration_path, params: invalid_params
+        get new_material_path
+        # 未ログインなので materials の認可で sign_in にリダイレクトされる
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

オートログイン関連の調査の過程で、User モデルおよびサインアップフロー
（sign in on sign up）について現状把握を行った結果、Devise のデフォルト
挙動で要件が満たされていることが確認できた。

一方で User モデルのテストは display_name とアソシエーションのみが
カバーされており、Devise validatable 由来の email / password バリデー
ション、および「サインアップ → 自動ログイン → root_path リダイレクト」
というアプリ固有の配線部分はテストで担保されていなかった。

本 PR ではこれらの未カバー領域にテストを追加し、アプリ固有の挙動を
回帰防止できる状態にする。

## 変更内容

- `spec/models/user_spec.rb` に以下のテストを追加
  - email バリデーション（presence / format / uniqueness / case_insensitive_keys）
  - password バリデーション（境界値 6/5/128/129、presence）
  - Devise モジュール構成（5 つのモジュールがすべて有効）
- `spec/requests/users/registrations_spec.rb` を新規作成
  - 正常系: User 増加、root_path リダイレクト、display_name 保存、自動ログインの統合確認
  - 異常系: User 不変、未ログインのまま

## 影響範囲

- テストコードのみの追加。アプリのプロダクションコード（モデル / コントローラー /
  ビュー / ルート / 設定）には変更なし

## 確認方法

`docker compose exec web bundle exec rspec spec/models/user_spec.rb spec/requests/users/registrations_spec.rb` を実行


## スクリーンショット

該当なし（テストコードの追加のみで UI 変更はない）。

## 補足事項

- テスト方針として **「gem の内部実装はテストせず、アプリ固有の配線・カスタマイズを
  テストする」** を採用した
  - email / password バリデーションは Devise 提供だが「アプリのユーザー登録仕様の
    明文化」として model spec に含めた境界例
  - Devise モジュール構成テストは「認証まわりの構成（設定）の契約」を担保する目的
- system test / E2E テストは UI 変更の可能性があるため本 PR では追加していない
- 永続ログイン（Remember Me）の実機検証は別 issue で別途対応予定

## 関連 Issue
#213 も参照する。



close #212 