### PR TITLE
feat: Topic / ReviewTopic データモデルを追加

### DIFF
--- a/app/models/review_topic.rb
+++ b/app/models/review_topic.rb
@@ -1,0 +1,6 @@
+class ReviewTopic < ApplicationRecord
+  belongs_to :review
+  belongs_to :topic
+
+  validates :review_id, uniqueness: { scope: :topic_id }
+end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1,0 +1,13 @@
+class Topic < ApplicationRecord
+  has_many :review_topics, dependent: :destroy
+  has_many :reviews, through: :review_topics
+
+  validates :name, presence: true, uniqueness: true, length: { maximum: 50 }
+
+  def self.find_or_create_from_input(input)
+    normalized = input.to_s.strip.downcase
+    return nil if normalized.empty?
+
+    find_or_create_by!(name: normalized)
+  end
+end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -5,9 +5,9 @@ class Topic < ApplicationRecord
   validates :name, presence: true, uniqueness: true, length: { maximum: 50 }
 
   def self.find_or_create_from_input(input)
-    normalized = input.to_s.strip.downcase
-    return nil if normalized.empty?
+    normalized_name = input.to_s.strip.downcase
+    return nil if normalized_name.empty?
 
-    find_or_create_by!(name: normalized)
+    find_or_create_by!(name: normalized_name)
   end
 end

--- a/db/migrate/20260508092651_create_topics.rb
+++ b/db/migrate/20260508092651_create_topics.rb
@@ -1,0 +1,10 @@
+class CreateTopics < ActiveRecord::Migration[7.2]
+  def change
+    create_table :topics do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+    add_index :topics, :name, unique: true
+  end
+end

--- a/db/migrate/20260508093204_create_review_topics.rb
+++ b/db/migrate/20260508093204_create_review_topics.rb
@@ -6,6 +6,6 @@ class CreateReviewTopics < ActiveRecord::Migration[7.2]
 
       t.timestamps
     end
-    add_index :review_topics, [:review_id, :topic_id], unique: true
+    add_index :review_topics, [ :review_id, :topic_id ], unique: true
   end
 end

--- a/db/migrate/20260508093204_create_review_topics.rb
+++ b/db/migrate/20260508093204_create_review_topics.rb
@@ -1,0 +1,11 @@
+class CreateReviewTopics < ActiveRecord::Migration[7.2]
+  def change
+    create_table :review_topics do |t|
+      t.references :review, null: false, foreign_key: true
+      t.references :topic,  null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :review_topics, [:review_id, :topic_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_01_30_052911) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_08_093204) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,6 +21,16 @@ ActiveRecord::Schema[7.2].define(version: 2026_01_30_052911) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["url"], name: "index_materials_on_url"
+  end
+
+  create_table "review_topics", force: :cascade do |t|
+    t.bigint "review_id", null: false
+    t.bigint "topic_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["review_id", "topic_id"], name: "index_review_topics_on_review_id_and_topic_id", unique: true
+    t.index ["review_id"], name: "index_review_topics_on_review_id"
+    t.index ["topic_id"], name: "index_review_topics_on_topic_id"
   end
 
   create_table "reviews", force: :cascade do |t|
@@ -36,6 +46,13 @@ ActiveRecord::Schema[7.2].define(version: 2026_01_30_052911) do
     t.index ["user_id"], name: "index_reviews_on_user_id"
   end
 
+  create_table "topics", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_topics_on_name", unique: true
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -49,6 +66,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_01_30_052911) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "review_topics", "reviews"
+  add_foreign_key "review_topics", "topics"
   add_foreign_key "reviews", "materials"
   add_foreign_key "reviews", "users"
 end

--- a/spec/factories/review_topics.rb
+++ b/spec/factories/review_topics.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :review_topic do
+    review
+    topic
+  end
+end

--- a/spec/factories/topics.rb
+++ b/spec/factories/topics.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :topic do
+    sequence(:name) { |n| "topic#{n}" }
+  end
+end

--- a/spec/models/review_topic_spec.rb
+++ b/spec/models/review_topic_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe ReviewTopic, type: :model do
+  describe "ファクトリ" do
+    it "デフォルトで valid なオブジェクトを生成する" do
+      expect(build(:review_topic)).to be_valid
+    end
+  end
+
+  describe "アソシエーション" do
+    it "review が nil で invalid（belongs_to required・異常系）" do
+      review_topic = build(:review_topic, review: nil)
+      expect(review_topic).not_to be_valid
+    end
+
+    it "topic が nil で invalid（belongs_to required・異常系）" do
+      review_topic = build(:review_topic, topic: nil)
+      expect(review_topic).not_to be_valid
+    end
+  end
+
+  describe "一意性制約（review_id と topic_id の組み合わせ）" do
+    let(:review) { create(:review) }
+    let(:topic) { create(:topic) }
+
+    it "同一 review と 同一 topic の 2 件目は invalid（異常系）" do
+      create(:review_topic, review: review, topic: topic)
+      review_topic_with_same_review_and_topic = build(:review_topic, review: review, topic: topic)
+      expect(review_topic_with_same_review_and_topic).not_to be_valid
+    end
+  end
+end

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -1,0 +1,88 @@
+require "rails_helper"
+
+RSpec.describe Topic, type: :model do
+  describe "ファクトリ" do
+    it "デフォルトで valid なオブジェクトを生成する" do
+      expect(build(:topic)).to be_valid
+    end
+  end
+
+  describe "name" do
+    it "nil で invalid（presence 違反・異常系）" do
+      topic = build(:topic, name: nil)
+      expect(topic).not_to be_valid
+    end
+
+    it "重複した name で invalid（uniqueness 違反・異常系）" do
+      create(:topic, name: "ruby")
+      topic_with_same_name = build(:topic, name: "ruby")
+      expect(topic_with_same_name).not_to be_valid
+    end
+
+    it "51 文字の name で invalid（length 境界・異常系）" do
+      topic = build(:topic, name: "a" * 51)
+      expect(topic).not_to be_valid
+    end
+
+    it "50 文字の name で valid（length 境界・正常系）" do
+      topic = build(:topic, name: "a" * 50)
+      expect(topic).to be_valid
+    end
+  end
+
+  describe ".find_or_create_from_input" do
+    context "正常系" do
+      it "新規入力で Topic を作成して返す" do
+        expect {
+          Topic.find_or_create_from_input("ruby")
+        }.to change(Topic, :count).by(1)
+      end
+
+      it "大文字を含む入力で既存 Topic に寄せる（正規化）" do
+        existing_topic = create(:topic, name: "ruby")
+        expect(Topic.find_or_create_from_input("Ruby")).to eq(existing_topic)
+      end
+
+      it "前後に空白を含む入力で既存 Topic に寄せる（正規化）" do
+        existing_topic = create(:topic, name: "ruby")
+        expect(Topic.find_or_create_from_input("  ruby  ")).to eq(existing_topic)
+      end
+    end
+
+    context "異常系（空入力）" do
+      it "空文字で nil を返す" do
+        expect(Topic.find_or_create_from_input("")).to be_nil
+      end
+
+      it "空白のみの入力で nil を返す" do
+        expect(Topic.find_or_create_from_input("   ")).to be_nil
+      end
+
+      it "nil 入力で nil を返す" do
+        expect(Topic.find_or_create_from_input(nil)).to be_nil
+      end
+    end
+  end
+
+  describe "アソシエーション" do
+    describe "has_many :reviews, through: :review_topics" do
+      it "中間レコード（review_topic）経由で関連 review を取得できる" do
+        topic = create(:topic)
+        review = create(:review)
+        create(:review_topic, topic: topic, review: review)
+
+        expect(topic.reviews).to include(review)
+      end
+    end
+
+    describe "dependent: :destroy" do
+      it "topic 削除時に紐づく review_topics も削除される" do
+        topic = create(:topic)
+        review = create(:review)
+        create(:review_topic, topic: topic, review: review)
+
+        expect { topic.destroy }.to change(ReviewTopic, :count).by(-1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

教材レビューに「分野（topic）」を多対多で紐付けるためのデータモデルを追加するための PR。

同じ教材でもレビュアーによって「何の分野として学んだか」は異なるため、分野は教材ではなく Review に紐付ける設計を採用。集計対象として横断利用するため Topic を正規化マスタとして持ち、`Review ─ ReviewTopic ─ Topic` の多対多構造で実装する。

本 PR ではモデル・マイグレーション・spec のみ整備。

## 変更内容

- `Topic` モデル新規追加：`name` の presence / uniqueness / length(50) 検証、`find_or_create_from_input` クラスメソッド、`has_many :review_topics, dependent: :destroy`、`has_many :reviews, through: :review_topics`
- `ReviewTopic` モデル新規追加：`belongs_to :review` / `:topic`、`(review_id, topic_id)` 複合 unique 検証
- マイグレーション 2 本追加：`topics` テーブル / `review_topics` テーブル（外部キー・各種 index）
- `db/schema.rb` 更新
- spec 追加：`topic_spec.rb`（13 examples）、`review_topic_spec.rb`（4 examples）
- factory 追加：`topics.rb`、`review_topics.rb`
- マイグレーションの rubocop Layout 違反を修正（chore）
- `find_or_create_from_input` の変数名を `normalized_name` に変更（refactor）

## 影響範囲

- 既存機能（Materials / Reviews / Users）への影響なし
- DB に `topics` / `review_topics` テーブルが追加される（既存テーブルへの破壊的変更なし）
- 後続 issue（Review への topic 付与 UX、MaterialRecommender 等）の基盤

## 確認方法

1. ブランチをチェックアウト
2. `docker compose exec web bundle exec rails db:migrate` でマイグレーション実行
3. `docker compose exec web bundle exec rails console` で以下を確認：
   - `Topic.find_or_create_from_input("Ruby")` で Topic が新規作成される
   - 続けて `Topic.find_or_create_from_input("ruby")` で同じ Topic が返る（重複作成されない）
   - `Topic.find_or_create_from_input("")` / `Topic.find_or_create_from_input(nil)` で `nil` が返る
4. `docker compose exec web bundle exec rspec` で全 spec が green になることを確認（106 examples, 0 failures）

## スクリーンショット

なし

## 補足事項

- `Topic.find_or_create_from_input` は将来の自由入力（カンマ区切り）の前処理として実装。別の issue（Review への topic 付与）でフォーム入力から呼び出す予定
- `dependent: :destroy` は管理者操作・データクリーンアップ向けの安全装置。一般ユーザーは Topic を直接削除しない設計
- alias 機能（`aws` / `amazon web service` の表記揺れ対応）は別 issue として切り出し済み
- ローカルで rubocop / brakeman / rspec を実行済み（全て clean）

## 関連 Issue

Closes #216 