### PR TITLE
Review に topic を付与できるようにする（フォーム / 表示 / seed）

### DIFF
--- a/app/controllers/materials_controller.rb
+++ b/app/controllers/materials_controller.rb
@@ -30,7 +30,7 @@ class MaterialsController < ApplicationController
     # N+1問題を防ぐため includes を使用
     # @material.reviews.includes(:user)
     # インスタンス変数に代入するか、ビューで直接使う形にする
-    @reviews = @material.reviews.includes(:user).order(created_at: :desc)
+    @reviews = @material.reviews.includes(:user, :topics).order(created_at: :desc)
 
     # @reviews = @material.reviews.order(created_at: :desc)
     # 後でkaminariを使ってページネーション予定

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -12,7 +12,7 @@ class ReviewsController < ApplicationController
     else
       # redirect_to @material, alert: "評価の投稿に失敗しました: #{@review.errors.full_messages.join(', ')}"
       flash.now[:alert] = "評価の投稿に失敗しました: #{@review.errors.full_messages.join(', ')}"
-      @reviews = @material.reviews.includes(:user).order(created_at: :desc)
+      @reviews = @material.reviews.includes(:user, :topics).order(created_at: :desc)
       render "materials/show", status: :unprocessable_entity
     end
   end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -7,6 +7,7 @@ class ReviewsController < ApplicationController
     @review.user = current_user
 
     if @review.save
+      assign_topics(@review, @review.topic_names)
       redirect_to material_path(@material), notice: "評価を投稿しました"
     else
       # redirect_to @material, alert: "評価の投稿に失敗しました: #{@review.errors.full_messages.join(', ')}"
@@ -24,6 +25,12 @@ class ReviewsController < ApplicationController
   end
 
   def review_params
-    params.require(:review).permit(:start_level, :difficulty_rating, :comment)
+    params.require(:review).permit(:start_level, :difficulty_rating, :comment, :topic_names)
+  end
+
+  def assign_topics(review, topic_names)
+    review.topics = topic_names.to_s.split(",").filter_map do |name|
+      Topic.find_or_create_from_input(name)
+    end.uniq
   end
 end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -2,6 +2,12 @@ class Review < ApplicationRecord
   belongs_to :user
   belongs_to :material
 
+  has_many :review_topics, dependent: :destroy
+  has_many :topics, through: :review_topics
+
+  # フォームから受け取る「カンマ区切りの分野文字列」。DB カラムではない仮想属性。
+  attr_accessor :topic_names
+
   # enumの定義
   enum :start_level, {
     complete_beginner: 1,  # 全くの初心者

--- a/app/views/reviews/_form.html.erb
+++ b/app/views/reviews/_form.html.erb
@@ -48,6 +48,12 @@
       <%= f.text_area :comment, rows: 4, placeholder: "この教材についての感想や補足情報があれば記入してください", class: "w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white text-gray-900 placeholder-gray-400" %>
     </div>
 
+    <!-- 分野（任意・カンマ区切り） -->
+    <div>
+      <%= f.label :topic_names, "分野（任意・カンマ区切り）", class: "block text-sm font-medium text-gray-700 mb-2" %>
+      <%= f.text_field :topic_names, placeholder: "ruby, rails, docker", class: "w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white text-gray-900 placeholder-gray-400" %>
+    </div>
+
     <!-- 送信ボタン -->
     <div>
       <%= f.submit "評価を投稿", class: "w-full bg-blue-600 text-white font-medium py-2 px-4 rounded-md hover:bg-blue-700 transition-colors duration-200" %>

--- a/app/views/reviews/_item.html.erb
+++ b/app/views/reviews/_item.html.erb
@@ -38,4 +38,14 @@
       <p class="text-sm text-gray-700 whitespace-pre-wrap"><%= review.comment %></p>
     </div>
   <% end %>
+
+  <!-- 分野バッジ -->
+  <%# 現状は見やすさ優先で badge-error（赤色）を使用。デザインは将来見直し予定 %>
+  <% if review.topics.any? %>
+    <div class="mt-3 flex flex-wrap gap-1">
+      <% review.topics.each do |topic| %>
+        <span class="badge badge-error"><%= topic.name %></span>
+      <% end %>
+    </div>
+  <% end %>
 </div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,3 +7,9 @@
 #   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
+
+# 初期 Topic を投入する。
+# 既に同名の Topic が存在する場合は新規作成しない（find_or_create_by! による冪等性）。
+%w[ruby rails javascript typescript react git docker sql html css linux database].each do |name|
+  Topic.find_or_create_by!(name: name)
+end

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -68,6 +68,31 @@ RSpec.describe Review, type: :model do
     end
   end
 
+  describe "topics アソシエーション（has_many :through :review_topics）" do
+    it "review.topics に Topic を代入すると関連が引ける（正常系）" do
+      review = create(:review)
+      topic1 = create(:topic)
+      topic2 = create(:topic)
+      review.topics = [ topic1, topic2 ]
+      expect(review.reload.topics).to contain_exactly(topic1, topic2)
+    end
+
+    it "review を destroy すると紐づく review_topics も destroy される（dependent: :destroy）" do
+      review = create(:review)
+      topic1 = create(:topic)
+      review.topics = [ topic1 ]
+      expect { review.destroy }.to change(ReviewTopic, :count).by(-1)
+    end
+    it "同じ Topic を 2 回紐づけようとすると複合 unique で 2 件目は無効（境界・異常系）" do
+      review = create(:review)
+      topic1 = create(:topic)
+      review.review_topics.create!(topic: topic1)
+      second_review_topic = review.review_topics.build(topic: topic1)
+      expect(second_review_topic).not_to be_valid
+      expect(second_review_topic.errors[:review_id]).to be_present
+    end
+  end
+
   describe "一意性制約（user_id と material_id の組み合わせ）" do
     let(:user) { create(:user) }
     let(:material) { create(:material) }

--- a/spec/requests/reviews_spec.rb
+++ b/spec/requests/reviews_spec.rb
@@ -115,5 +115,58 @@ RSpec.describe "Reviews", type: :request do
         expect(Review.last.user).to eq(user)
       end
     end
+
+    context "ログイン済み + topic_names を含む" do
+      before { sign_in user }
+
+      it "カンマ区切り 2 件で Topic 2 件が紐づく（正常系）" do
+        post material_reviews_path(material), params: {
+          review: valid_params[:review].merge(topic_names: "ruby, rails")
+        }
+        expect(Review.last.topics.pluck(:name)).to contain_exactly("ruby", "rails")
+      end
+      it "topic_names が空文字でも Review は作成され、topic は 0 件（境界・正常系）" do
+        expect {
+          post material_reviews_path(material), params: {
+            review: valid_params[:review].merge(topic_names: "")
+          }
+        }.to change(Review, :count).by(1)
+        expect(Review.last.topics).to be_empty
+      end
+      it "topic_names 未指定でも Review は作成される（境界・正常系）" do
+        expect {
+          post material_reviews_path(material), params: valid_params
+        }.to change(Review, :count).by(1)
+        expect(Review.last.topics).to be_empty
+      end
+      it "同じレビュー内 'ruby, ruby' は Topic 1 件のみ紐づく（uniq による重複除去）" do
+        post material_reviews_path(material), params: {
+          review: valid_params[:review].merge(topic_names: "ruby, ruby")
+        }
+        expect(Review.last.topics.pluck(:name)).to eq([ "ruby" ])
+      end
+      it "同じレビュー内 'Ruby, ruby' は Topic 1 件のみ紐づく（正規化 + uniq）" do
+        post material_reviews_path(material), params: {
+          review: valid_params[:review].merge(topic_names: "Ruby, ruby")
+        }
+        expect(Review.last.topics.pluck(:name)).to eq([ "ruby" ])
+      end
+      it "同じレビュー内 'ruby, , rails' は空白要素を無視して 2 件紐づく（filter_map）" do
+        post material_reviews_path(material), params: {
+          review: valid_params[:review].merge(topic_names: "ruby, , rails")
+        }
+        expect(Review.last.topics.pluck(:name)).to contain_exactly("ruby", "rails")
+      end
+      it "異なるレビューで 'Ruby' と 'ruby' を送ると同じ Topic に寄る（Topic マスタの正規化）" do
+        post material_reviews_path(material), params: {
+          review: valid_params[:review].merge(topic_names: "Ruby")
+        }
+        other_material = create(:material)
+        post material_reviews_path(other_material), params: {
+          review: valid_params[:review].merge(topic_names: "ruby")
+        }
+        expect(Topic.where(name: "ruby").count).to eq(1)
+      end
+    end
   end
 end


### PR DESCRIPTION
## 概要

#216  で導入した Topic / ReviewTopic モデルを Review 作成フローに組み込み、ユーザーがレビュー投稿時にカンマ区切りで分野（topic）を自由入力でき、教材詳細ページの各レビューに topic がバッジ表示されるようにする。

将来の推薦ロジック #218 のためのデータ蓄積の入り口を整える位置づけ。

## 変更内容

- Review モデル
  - `has_many :review_topics, dependent: :destroy`
  - `has_many :topics, through: :review_topics`
  - `attr_accessor :topic_names`（DB カラムではない仮想属性）
- ReviewsController
  - strong params に `:topic_names` を追加
  - `assign_topics` で `split` + `filter_map` + `uniq` による Topic 変換と関連付け
    - `filter_map` で空白要素（nil）を除外
    - `uniq` で同レビュー内の重複（"ruby, ruby" 等）を除外
    - `Topic.find_or_create_from_input` による `strip + downcase` 正規化
- N+1 対策
  - `materials_controller#show` と `reviews_controller` 失敗パスの `@reviews` に `includes(:user, :topics)` を追加
- ビュー
  - `_form.html.erb`：`f.text_field :topic_names` でカンマ区切り入力欄を追加（プレースホルダ "ruby, rails, docker"）
  - `_item.html.erb`：DaisyUI `badge` で topic を表示
- `db/seeds.rb`：初期 Topic 12 件を `find_or_create_by!` で冪等投入
- spec
  - `spec/models/review_spec.rb`：topics 関連の動作 spec を追加
  - `spec/requests/reviews_spec.rb`：topic_names シナリオを 7 件追加

## 影響範囲

- レビュー投稿フロー（reviews#create）
- 教材詳細ページのレビュー一覧表示（materials#show）
- `topics` / `review_topics` テーブルへの新規データ
- 既存の評価機能（start_level / difficulty_rating / comment）には影響なし

## 確認方法

1. `docker compose exec web bundle exec rails db:seed` で 12 件の初期 Topic を投入
2. ブラウザでログインし、教材詳細ページへアクセス
3. レビューフォームの「分野（任意・カンマ区切り）」欄に `Ruby, ruby, , rails` を入力して投稿
4. レビュー一覧に「ruby」「rails」の 2 件の赤色バッジが表示されることを確認
   - `Ruby` と `ruby` が 1 件に集約（正規化）
   - `,,`（空白要素）が無視される
5. 別の教材で別の topic を付けて投稿し、独立して表示されることを確認
6. ローカルで CI 3 種が green（rspec 116 examples / rubocop no offenses / brakeman no warnings）

## スクリーンショット



## 補足事項

- topic 表示の色は **現状の見やすさ優先**で `badge-error`（赤）を選択。デザインは将来見直し予定（`_item.html.erb` に ERB コメントで明記）

## 関連Issue

Closes #217 