### PR TITLE
教材一覧におすすめ枠を追加（MaterialRecommender 実装）

### DIFF
--- a/app/controllers/materials_controller.rb
+++ b/app/controllers/materials_controller.rb
@@ -7,6 +7,9 @@ class MaterialsController < ApplicationController
     # 検索キーワードの有無を判定
     @search_keyword = params.dig(:q, :title_cont)
     # @materials = Material.order(created_at: :desc).page(params[:page])
+
+    # ログインユーザーには「あなたへのおすすめ」を、未ログインには空を渡す
+    @recommended = user_signed_in? ? MaterialRecommender.new(current_user).recommend : Material.none
   end
 
   def new

--- a/app/services/material_recommender.rb
+++ b/app/services/material_recommender.rb
@@ -1,0 +1,27 @@
+class MaterialRecommender
+  MAX_LIMIT = 50
+  TOP_TOPIC_LIMIT = 5
+
+  def initialize(user)
+    @user = user
+  end
+
+  def recommend(limit: 10)
+    safe_limit = limit.to_i.clamp(1, MAX_LIMIT)
+    usage_counts = @user.reviews.joins(:topics).group("topics.id").count
+    top_usage_pairs = usage_counts.sort_by { |_topic_id, count| -count }.first(TOP_TOPIC_LIMIT)
+    top_user_topic_ids = top_usage_pairs.map { |topic_id, _count| topic_id }
+    return Material.none if top_user_topic_ids.empty?
+
+    user_reviewed_material_ids = @user.reviews.select(:material_id)
+
+    Material
+      .where.not(id: user_reviewed_material_ids)
+      .joins(reviews: :topics)
+      .where(topics: { id: top_user_topic_ids })
+      .select("materials.*, COUNT(DISTINCT review_topics.id) AS matched_review_topics_count")
+      .group("materials.id")
+      .order(matched_review_topics_count: :desc)
+      .limit(safe_limit)
+  end
+end

--- a/app/views/materials/index.html.erb
+++ b/app/views/materials/index.html.erb
@@ -14,6 +14,29 @@
     </div>
   </div>
 
+  <!-- あなたへのおすすめ（ログインユーザーで履歴があるときだけ表示） -->
+  <% if @recommended.any? %>
+    <div class="mb-10">
+      <h2 class="text-2xl font-bold text-gray-300 mb-4">あなたへのおすすめ</h2>
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        <% @recommended.each do |material| %>
+          <div class="bg-white rounded-lg shadow-md hover:shadow-lg transition p-6">
+            <h3 class="text-xl font-semibold text-gray-800 mb-3 line-clamp-2">
+              <%= link_to material.title, material_path(material), class: "hover:text-blue-600 transition" %>
+            </h3>
+            <% if material.description.present? %>
+              <p class="text-gray-600 mb-4 line-clamp-3"><%= material.description %></p>
+            <% end %>
+            <div class="flex items-center justify-between text-sm text-gray-500">
+              <span><%= material.created_at.strftime("%Y年%m月%d日") %></span>
+              <%= link_to "詳細を見る", material_path(material), class: "text-blue-500 hover:text-blue-700 font-medium" %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+
   <!-- 検索結果のヘッダー -->
   <div class="mb-6">
     <% if @search_keyword.present? %>

--- a/spec/requests/materials_spec.rb
+++ b/spec/requests/materials_spec.rb
@@ -7,6 +7,12 @@ RSpec.describe "Materials", type: :request do
       expect(response).to have_http_status(:ok)
     end
 
+    it "ログイン済みでも 200 を返す（おすすめ処理を含めてエラーにならない・正常系）" do
+      sign_in create(:user)
+      get materials_path
+      expect(response).to have_http_status(:ok)
+    end
+
     it "登録済みの教材が body に含まれる（正常系）" do
       create(:material, title: "Ruby 入門")
       create(:material, title: "Python 入門")

--- a/spec/services/material_recommender_spec.rb
+++ b/spec/services/material_recommender_spec.rb
@@ -1,0 +1,178 @@
+require "rails_helper"
+
+RSpec.describe MaterialRecommender do
+  describe "#recommend" do
+    context "正常系" do
+      it "ユーザーの興味 topic と一致する review_topic を持つ未レビュー教材を返す" do
+        user = create(:user)
+        ruby = create(:topic, name: "ruby")
+
+        # user が ruby topic でレビュー → user の興味が ruby になる
+        reviewed_material = create(:material)
+        user_review = create(:review, user: user, material: reviewed_material)
+        user_review.topics << ruby
+
+        # 他ユーザーが別の（user 未レビューの）教材に ruby topic でレビュー
+        other_user = create(:user)
+        unreviewed_material = create(:material)
+        other_review = create(:review, user: other_user, material: unreviewed_material)
+        other_review.topics << ruby
+
+        expect(MaterialRecommender.new(user).recommend).to include(unreviewed_material)
+      end
+
+      it "既にレビュー済みの教材は除外される" do
+        user = create(:user)
+        ruby = create(:topic, name: "ruby")
+
+        # user 自身が ruby topic でレビュー（興味は ruby と一致するが、既レビュー）
+        reviewed_material = create(:material)
+        user_review = create(:review, user: user, material: reviewed_material)
+        user_review.topics << ruby
+
+        expect(MaterialRecommender.new(user).recommend).not_to include(reviewed_material)
+      end
+      it "ユーザー topic と一致しない教材は返らない" do
+        user = create(:user)
+        ruby = create(:topic, name: "ruby")
+        javascript = create(:topic, name: "javascript")
+
+        # user の興味は ruby
+        ruby_material = create(:material)
+        user_review = create(:review, user: user, material: ruby_material)
+        user_review.topics << ruby
+
+        # 他ユーザーが javascript だけでレビューした教材（user の興味 ruby と不一致）
+        other_user = create(:user)
+        javascript_material = create(:material)
+        other_user_review = create(:review, user: other_user, material: javascript_material)
+        other_user_review.topics << javascript
+
+        expect(MaterialRecommender.new(user).recommend).not_to include(javascript_material)
+      end
+      it "matched_review_topics_count の多い順にソートされる（三角測量）" do
+        user = create(:user)
+        ruby = create(:topic, name: "ruby")
+        rails = create(:topic, name: "rails")
+
+        # user の興味は ruby と rails
+        user_material = create(:material)
+        user_review = create(:review, user: user, material: user_material)
+        user_review.topics << [ ruby, rails ]
+
+        # material_a: 他ユーザーが ruby と rails でレビュー（マッチ 2）
+        other_user_a = create(:user)
+        material_a = create(:material)
+        review_a = create(:review, user: other_user_a, material: material_a)
+        review_a.topics << [ ruby, rails ]
+
+        # material_b: 他ユーザーが ruby だけでレビュー（マッチ 1）
+        other_user_b = create(:user)
+        material_b = create(:material)
+        review_b = create(:review, user: other_user_b, material: material_b)
+        review_b.topics << ruby
+
+        result = MaterialRecommender.new(user).recommend
+
+        expect(result.to_a).to eq([ material_a, material_b ])
+      end
+
+      it "使用回数が Top-5 に入らない topic だけにマッチする教材は推薦されない（Top-N 絞り込み）" do
+        user = create(:user)
+        topics = (1..6).map { |i| create(:topic, name: "topic#{i}") }
+
+        # user が material_1 に 6 topic 全部、material_2 に上位 5 topic を付ける
+        # → topic1..5 は使用回数 2、topic6 は使用回数 1（最下位で Top-5 から外れる）
+        material_1 = create(:material)
+        create(:review, user: user, material: material_1).topics << topics
+        material_2 = create(:material)
+        create(:review, user: user, material: material_2).topics << topics[0..4]
+
+        other_user = create(:user)
+
+        # Top-5 内（topic1）にマッチする未レビュー教材 → 推薦される
+        top5_topic_material = create(:material)
+        create(:review, user: other_user, material: top5_topic_material).topics << topics[0]
+
+        # Top-5 外（topic6）だけにマッチする未レビュー教材 → 推薦されない
+        excluded_topic_material = create(:material)
+        create(:review, user: other_user, material: excluded_topic_material).topics << topics[5]
+
+        result = MaterialRecommender.new(user).recommend
+
+        expect(result).to include(top5_topic_material)
+        expect(result).not_to include(excluded_topic_material)
+      end
+    end
+
+    context "異常系（履歴なし）" do
+      it "topic 履歴がないユーザーには Material.none を返す" do
+        user = create(:user)
+
+        expect(MaterialRecommender.new(user).recommend).to be_empty
+      end
+    end
+
+    context "limit の境界値" do
+      it "limit: 9999 を渡しても MAX_LIMIT=50 件で打ち切られる（上限境界）" do
+        user = create(:user)
+        ruby = create(:topic, name: "ruby")
+
+        # user の興味は ruby
+        user_material = create(:material)
+        user_review = create(:review, user: user, material: user_material)
+        user_review.topics << ruby
+
+        # 51 件の候補教材（他ユーザーが ruby でレビュー）を用意
+        51.times do
+          other_user_material = create(:material)
+          other_user = create(:user)
+          other_user_review = create(:review, user: other_user, material: other_user_material)
+          other_user_review.topics << ruby
+        end
+
+        result = MaterialRecommender.new(user).recommend(limit: 9999)
+
+        expect(result.to_a.size).to eq(MaterialRecommender::MAX_LIMIT)
+      end
+      it "limit: 0 を渡しても 1 件は返るスコープになる（下限境界）" do
+        user = create(:user)
+        ruby = create(:topic, name: "ruby")
+
+        # user の興味は ruby
+        user_material = create(:material)
+        user_review = create(:review, user: user, material: user_material)
+        user_review.topics << ruby
+
+        # 候補を 2 件用意（1 件に絞られることを確認するため複数）
+        2.times do
+          other_user = create(:user)
+          other_user_material = create(:material)
+          other_user_review = create(:review, user: other_user, material: other_user_material)
+          other_user_review.topics << ruby
+        end
+
+        expect(MaterialRecommender.new(user).recommend(limit: 0).to_a.size).to eq(1)
+      end
+      it "limit: -1 を渡しても 1 件は返るスコープになる（下限境界）" do
+        user = create(:user)
+        ruby = create(:topic, name: "ruby")
+
+        # user の興味は ruby
+        user_material = create(:material)
+        user_review = create(:review, user: user, material: user_material)
+        user_review.topics << ruby
+
+        # 候補を 2 件用意（1 件に絞られることを確認するため複数）
+        2.times do
+          other_user = create(:user)
+          other_user_material = create(:material)
+          other_user_review = create(:review, user: other_user, material: other_user_material)
+          other_user_review.topics << ruby
+        end
+
+        expect(MaterialRecommender.new(user).recommend(limit: -1).to_a.size).to eq(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

ログインユーザーの過去レビューに付与された分野（topic）を集計し、その興味と一致する未レビュー教材を「あなたへのおすすめ」として教材一覧の上部に表示する機能を追加する。

 #216 ~ #217 で Review に topic が多対多で紐づくようになったため、その集計を使った推薦を実装した。推薦ロジックは `MaterialRecommender`（`app/services/`）に切り出し、将来の拡張（重み付け・ネガティブ信号・キャッシュ等）に備えている。

## 変更内容

- `MaterialRecommender` サービスを追加：ログインユーザーの **使用回数 Top-5 の topic** を興味とし、一致する review_topic を多く持つ未レビュー教材をマッチ数の多い順に返す
  - `Arel.sql` を使わず `select` 別名 + symbol `order`、Top-N 抽出は Ruby 側ソートで実現
  - `limit` は `MAX_LIMIT = 50` で `clamp`（DoS 対策）、履歴ゼロは `Material.none`
- `materials#index` で `@recommended` をセット（未ログインは `Material.none`）
- 教材一覧（`index.html.erb`）に「あなたへのおすすめ」セクションを追加（空なら非表示）
- service spec 9 例（履歴なし / 既レビュー除外 / 不一致除外 / マッチ数ソート / limit 境界 / Top-5 絞り込み）と、request smoke test を追加

## 影響範囲

- 教材一覧ページ（`/materials`・root）のみ。ログインユーザーにおすすめ枠が追加表示される
- 既存の検索・一覧・教材詳細・レビュー機能には影響なし（追加のみ）
- 未ログインユーザーの見え方は変わらない（おすすめ枠は非表示）

## 確認方法

1. ユーザー A でログインし、教材 X をレビュー（分野欄に `ruby, rails` 等を入力）
2. ログアウト後ユーザー B でログインし、A が未レビューの教材 Y を同じ分野でレビュー
3. 再度ユーザー A でログインし `/materials` を開く
4. 上部の「あなたへのおすすめ」に教材 Y が表示されることを確認
5. ログアウト時・レビュー履歴ゼロのユーザーではおすすめ枠が非表示になることを確認

## スクリーンショット

特になし

## 補足事項

- 集計式自体の改善（出現回数による重み付け・正規化等）は他 issueで対応
- 推薦ロジックは `MaterialRecommender` の単一 public API（`recommend(limit:)`）に閉じており、内部実装を差し替えても controller / view に波及しない設計
- セキュリティ：SQL は固定文字列 + Hash/プレースホルダのみ、`limit` は clamp。brakeman 0 warnings

## 関連Issue

Closes #218