### PR TITLE
開発環境用のサンプル seed を追加（おすすめ機能の動作確認用）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,10 +22,24 @@ docker compose up
 
 ```bash
 docker compose exec web bundle exec rails db:migrate           # マイグレーション実行
+docker compose exec web bundle exec rails db:prepare           # DB 準備（未作成なら作成+schema+seed、既存ならマイグレーションのみ）
+docker compose exec web bundle exec rails db:seed              # 初期データ投入（seed）
+docker compose exec web bundle exec rails db:schema:load       # schema.rb から全テーブルを再構築（DB は drop せずデータは消える）
+docker compose exec web bundle exec rails db:drop              # DB 削除（破壊的・接続中だと失敗するため注意）
 docker compose exec web bundle exec rails console              # Rails コンソール
+docker compose exec web bundle exec rspec                      # テスト実行（RSpec）
 docker compose exec web bundle exec rubocop                    # Ruby Lint
 docker compose exec web bundle exec brakeman                   # セキュリティ脆弱性スキャン
 ```
+
+### seed（初期データ）
+
+`db/seeds.rb` は 2 部構成。
+
+- **Topic マスタ**（全環境）：ruby / rails などの分野マスタを `find_or_create_by!` で冪等に投入。
+- **開発用サンプルデータ**（`if Rails.env.development?` ガード内）：おすすめ機能（`MaterialRecommender`）の動作確認用に user / 教材 / レビュー（topic 付き）を投入。本番では実行されず、冪等なので何度 `db:seed` しても重複しない。
+
+`docker compose up` 時に走る `db:prepare` は、**DB が新規作成された場合のみ** seed を実行する（既存 DB ではマイグレーションのみ）。本番（Render）の `bin/render-build.sh` は `db:migrate` のみで seed を実行しないため、本番にサンプルデータは入らない。
 
 ### Docker 構成メモ
 
@@ -40,19 +54,28 @@ docker compose exec web bundle exec brakeman                   # セキュリテ
 
 ### ドメインモデル
 
-3 つのモデルが中心。
+5 つのモデルが中心。
 
 - **User**（Devise）— display_name（最大 50 文字）を持つ
 - **Material** — title（最大 100 文字）、URL（http/https のみ）、description（最大 5000 文字）
-- **Review** — User → Material の評価。`start_level`（学習開始レベル 1〜5）と `difficulty_rating`（難易度評価 1〜5）を持つ enum。同一ユーザーと教材の組み合わせは一意制約あり
+- **Review** — User → Material の評価。`start_level`（学習開始レベル 1〜5）と `difficulty_rating`（難易度評価 1〜5）を持つ enum。同一ユーザーと教材の組み合わせは一意制約あり。`has_many :topics, through: :review_topics` で分野（topic）を多対多で持ち、フォーム入力用の仮想属性 `topic_names`（カンマ区切り文字列）を持つ
+- **Topic** — 分野マスタ。name（最大 50 文字・一意）。`find_or_create_from_input` で入力を strip + downcase 正規化して引き当て / 新規作成
+- **ReviewTopic** — Review と Topic の中間テーブル。`[review_id, topic_id]` の複合一意制約
+
+**topic を Material ではなく Review に持たせる設計思想**：同じ教材でもレビュアーによって「何の分野として学んだか」は異なる（例：『プロを目指す人のためのRuby入門』を Ruby と捉える人、Web 開発と捉える人、オブジェクト指向と捉える人がいる）。Material に固定タグを付けるとこの感じ方の差が潰れてしまうため、topic は **Review に多対多で**紐づける（`Review ─ ReviewTopic ─ Topic`）。教材の「客観的分野」は事前に固定せず、Review 群の集計（→ 後述の教材推薦）から動的に導出する。
+
+### 教材推薦（あなたへのおすすめ）
+
+- `app/services/material_recommender.rb` — ログインユーザーの過去 review が持つ topic を集計し、一致 topic を多く持つ未レビュー教材を返す副作用なしの読み取りサービス
+- `materials#index` で `@recommended` にセットし、教材一覧の上部に「あなたへのおすすめ」として表示（未ログイン / レビュー履歴ゼロなら非表示）
 
 ### ルーティング構造
 
 ```
 root → materials#index
-resources :materials（検索: Ransack、タイトル部分一致）
-  resources :reviews（材料に対してネスト）
-resources :profiles
+resource  :profile,   only: [:show, :edit, :update]            # 単数 resource
+resources :materials, only: [:index, :new, :create, :show]     # 検索: Ransack（タイトル部分一致）
+  resources :reviews, only: [:create]                          # materials にネスト
 ```
 
 ### フロントエンド

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,3 +13,65 @@
 %w[ruby rails javascript typescript react git docker sql html css linux database].each do |name|
   Topic.find_or_create_by!(name: name)
 end
+
+# 開発環境専用のサンプルデータ。
+# おすすめ機能（MaterialRecommender）の動作確認を手入力なしで行うために投入する。
+if Rails.env.development?
+  DEV_PASSWORD = "password"
+
+  # dev ログイン情報：user1@example.com 〜 user3@example.com（いずれも password）
+  users = (1..3).map do |i|
+    User.find_or_create_by!(email: "user#{i}@example.com") do |u|
+      u.password = DEV_PASSWORD
+      u.display_name = "user#{i}"
+    end
+  end
+  user_1, user_2, user_3 = users
+
+  # サンプル教材
+  material_1 = Material.find_or_create_by!(title: "プロを目指す人のためのRuby入門") { |m| m.url = "https://example.com/ruby-book";   m.description = "Ruby 入門の定番" }
+  material_2 = Material.find_or_create_by!(title: "現場で使えるRails")            { |m| m.url = "https://example.com/rails-book";  m.description = "Rails 実践ガイド" }
+  material_3 = Material.find_or_create_by!(title: "JavaScript入門")             { |m| m.url = "https://example.com/js-book";     m.description = "JS の基礎" }
+  material_4 = Material.find_or_create_by!(title: "Docker実践ガイド")           { |m| m.url = "https://example.com/docker-book"; m.description = "Docker の実践" }
+  material_5 = Material.find_or_create_by!(title: "SQLアンチパターン") { |m| m.url = "https://example.com/sql-book"; m.description = "DB 設計の落とし穴" }
+
+  ruby       = Topic.find_by!(name: "ruby")
+  rails      = Topic.find_by!(name: "rails")
+  javascript = Topic.find_by!(name: "javascript")
+
+  # user_1 の興味を作る（ruby / rails）。material_1 は user_1 レビュー済み → おすすめから除外される
+  review = Review.find_or_create_by!(user: user_1, material: material_1) do |r|
+    r.start_level = :complete_beginner
+    r.difficulty_rating = :just_right
+  end
+  review.topics = [ ruby, rails ]
+
+  # material_2: user_2[ruby, rails] + user_3[ruby] → 一致 = 3 → おすすめ 1 位
+  review = Review.find_or_create_by!(user: user_2, material: material_2) do |r|
+    r.start_level = :intermediate_level
+    r.difficulty_rating = :difficult
+  end
+  review.topics = [ ruby, rails ]
+
+  review = Review.find_or_create_by!(user: user_3, material: material_2) do |r|
+    r.start_level = :basic_level
+    r.difficulty_rating = :just_right
+  end
+  review.topics = [ ruby ]
+
+  # material_4: user_2[ruby] → 一致 = 1 → おすすめ 2 位
+  review = Review.find_or_create_by!(user: user_2, material: material_4) do |r|
+    r.start_level = :entry_level
+    r.difficulty_rating = :easy
+  end
+  review.topics = [ ruby ]
+
+  # material_3: user_3[javascript] → user_1 の興味と不一致 → おすすめに出ない
+  review = Review.find_or_create_by!(user: user_3, material: material_3) do |r|
+    r.start_level = :complete_beginner
+    r.difficulty_rating = :very_easy
+  end
+  review.topics = [ javascript ]
+
+  # material_5: レビューなし → おすすめに出ない
+end


### PR DESCRIPTION
## 概要
おすすめ機能（MaterialRecommender）の動作確認のたびに「ユーザー作成 → ログイン → topic 付きレビュー → 別ユーザーで別教材をレビュー…」を手入力するのが面倒だった。開発環境だけにサンプルデータを seed で投入し、サンプルユーザーでログインするだけで「あなたへのおすすめ」を目視確認できるようにする。本番環境には影響を与えない。

## 変更内容
- `db/seeds.rb` に `if Rails.env.development?` ガードでサンプルデータ（user1〜3 / 教材 5 件 / レビュー 5 件＋topic）を追加。
- あわせて `CLAUDE.md` を topic 機能マージ後の現状に更新（ドメインモデル 3→5 モデル・教材推薦の追記・ルーティングの正確化・DB/テスト系コマンドと seed 説明の追記）。

## 影響範囲
- 開発環境のみ（`Rails.env.development?` ガード）。アプリのロジック・スキーマ変更はなく、追加されるのは dev の seed データとドキュメントのみ。

## 確認方法
1. `docker compose exec web bundle exec rails db:seed`（2 回流して冪等性も確認）
2. `user1@example.com` / `password` でログイン
3. `/materials` の「あなたへのおすすめ」に **現場で使えるRails → Docker実践ガイド** の順で表示され、Ruby入門 / JavaScript入門 / SQLアンチパターン が出ないことを確認

## スクリーンショット
特になし。

## 補足事項
- dev 用ユーザーのパスワードは固定値 `password` ですが、`Rails.env.development?` ガード＋本番で `db:seed` を呼ばない構成の二重で、本番には作られません。
- `material_4`（Docker 本）に `ruby` topic を付けているのは、おすすめ 2 位を作るための意図的なデモ配置です。
- 本 PR には `CLAUDE.md` の現状反映も含めています（軽微なドキュメント整合）。

## 関連Issue
Closes #223 