### PR TITLE
refactor: materials#show の view 責務を controller/model へ整理

### DIFF
--- a/app/controllers/materials_controller.rb
+++ b/app/controllers/materials_controller.rb
@@ -37,6 +37,9 @@ class MaterialsController < ApplicationController
 
     # @reviews = @material.reviews.order(created_at: :desc)
     # 後でkaminariを使ってページネーション予定
+
+    # 投稿フォーム用の空 Review。
+    @review = Review.new
   end
 
   private

--- a/app/models/material.rb
+++ b/app/models/material.rb
@@ -16,6 +16,14 @@ class Material < ApplicationRecord
     [ "title" ]
   end
 
+  # この教材が、指定ユーザーによって既にレビューされているかを返す。
+  # user が nil（未ログイン）なら false。
+  def reviewed_by?(user)
+    return false unless user
+
+    reviews.exists?(user: user)
+  end
+
   private
 
   def url_must_be_http_or_https

--- a/app/views/materials/show.html.erb
+++ b/app/views/materials/show.html.erb
@@ -39,7 +39,7 @@
     
     <!-- 評価投稿フォーム -->
     <% if user_signed_in? %>
-      <% if @material.reviews.exists?(user: current_user) %>
+      <% if @material.reviewed_by?(current_user) %>
         <p class="text-gray-500 text-sm mb-4 bg-yellow-50 p-3 rounded">
           ※この教材には既に評価を投稿済みです
         </p>

--- a/app/views/materials/show.html.erb
+++ b/app/views/materials/show.html.erb
@@ -44,7 +44,7 @@
           ※この教材には既に評価を投稿済みです
         </p>
       <% else %>
-        <%= render 'reviews/form', material: @material, review: Review.new %>
+        <%= render 'reviews/form', material: @material, review: @review %>
       <% end %>
     <% else %>
       <p class="text-gray-500 text-sm mb-4">※評価を投稿するにはログインが必要です</p>

--- a/spec/models/material_spec.rb
+++ b/spec/models/material_spec.rb
@@ -110,6 +110,34 @@ RSpec.describe Material, type: :model do
     end
   end
 
+  describe "#reviewed_by?" do
+    it "user が nil なら false（未ログイン想定）" do
+      material = create(:material)
+      expect(material.reviewed_by?(nil)).to be false
+    end
+
+    it "その user がこの教材をレビュー済みなら true" do
+      material = create(:material)
+      user = create(:user)
+      create(:review, material: material, user: user)
+      expect(material.reviewed_by?(user)).to be true
+    end
+
+    it "その user がこの教材を未レビューなら false" do
+      material = create(:material)
+      user = create(:user)
+      expect(material.reviewed_by?(user)).to be false
+    end
+
+    it "user が別教材をレビュー済みでも、この教材が未レビューなら false" do
+      material = create(:material)
+      other_material = create(:material)
+      user = create(:user)
+      create(:review, material: other_material, user: user)
+      expect(material.reviewed_by?(user)).to be false
+    end
+  end
+
   describe "Ransack 設定" do
     it "ransackable_attributes は title のみを返す" do
       expect(Material.ransackable_attributes).to eq [ "title" ]

--- a/spec/requests/reviews_spec.rb
+++ b/spec/requests/reviews_spec.rb
@@ -76,6 +76,18 @@ RSpec.describe "Reviews", type: :request do
       end
     end
 
+    context "ログイン済み + 一部不正（コメントは入力済み）で失敗したとき（入力保持）" do
+      before { sign_in user }
+
+      it "入力したコメントがフォームに残って再表示される" do
+        post material_reviews_path(material), params: {
+          review: valid_params[:review].merge(start_level: "")
+        }
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.body).to include("良かった")
+      end
+    end
+
     context "ログイン済み + 一意性違反（同一 user と 同一 material で 2 回 POST）" do
       before { sign_in user }
 


### PR DESCRIPTION
## 概要
教材詳細ページ（materials#show）の view に漏れていた MVC 責務を controller/model へ整理する。あわせて create 失敗時の入力保持バグを解消する。

## 変更内容
- `Material#reviewed_by?(user)` を追加し、view のレビュー済み判定 DB クエリを置き換え
- `materials#show` で `@review = Review.new` を準備し、view の `Review.new` を `@review` に変更
- 上記に対する spec を追加（model 4 件 / request 1 件）

## 影響範囲
- 教材詳細ページ（GET /materials/:id）の表示。レビュー済み表示・投稿フォームの挙動は従来と同等。
- create 失敗時のフォーム挙動：入力値が保持されるよう改善（従来は消えていた）。

## 確認方法
1. ログインして教材詳細ページに遷移
2. 評価フォームでコメントを入力し、「学習開始時のレベル」を未選択のまま投稿（わざと失敗させる）
3. 失敗フラッシュが表示され、入力したコメントがフォームに残っていることを確認
4. 既にレビュー済みの教材では「※この教材には既に評価を投稿済みです」が表示されることを確認

## スクリーンショット
特になし。

## 補足事項
特になし。

## 関連Issue
Closes #225 