### PR TITLE
feat: レビューの編集・削除（edit / update / destroy）を追加

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -1,5 +1,6 @@
 class ReviewsController < ApplicationController
   before_action :authenticate_user!
+  before_action :set_own_review, only: [ :edit, :update, :destroy ]
 
   def create
     set_material
@@ -17,8 +18,31 @@ class ReviewsController < ApplicationController
     end
   end
 
+  def edit
+    @review.topic_names = @review.topics.map(&:name).join(", ")
+  end
+
+  def update
+    if @review.update(review_params)
+      assign_topics(@review, @review.topic_names)
+      redirect_to material_path(@material), notice: "評価を更新しました"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @review.destroy!
+    redirect_to material_path(@material), notice: "評価を削除しました"
+  end
 
   private
+
+  # current_user 配下から探すので、他人のレビューは RecordNotFound（404）になり認可を兼ねる
+  def set_own_review
+    @review = current_user.reviews.find(params[:id])
+    @material = @review.material
+  end
 
   def set_material
     @material = Material.find(params[:material_id])

--- a/app/views/reviews/_form.html.erb
+++ b/app/views/reviews/_form.html.erb
@@ -56,7 +56,7 @@
 
     <!-- 送信ボタン -->
     <div>
-      <%= f.submit "評価を投稿", class: "w-full bg-blue-600 text-white font-medium py-2 px-4 rounded-md hover:bg-blue-700 transition-colors duration-200" %>
+      <%= f.submit (review.persisted? ? "評価を更新" : "評価を投稿"), class: "w-full bg-blue-600 text-white font-medium py-2 px-4 rounded-md hover:bg-blue-700 transition-colors duration-200" %>
     </div>
   <% end %>
 </div>

--- a/app/views/reviews/_item.html.erb
+++ b/app/views/reviews/_item.html.erb
@@ -48,4 +48,16 @@
       <% end %>
     </div>
   <% end %>
+
+  <!-- 自分のレビューにだけ編集／削除を表示 -->
+  <% if review.user == current_user %>
+    <div class="mt-3 flex gap-3">
+      <%= link_to "編集", edit_material_review_path(review.material, review),
+                  class: "text-sm text-blue-600 hover:text-blue-800" %>
+      <%= button_to "削除", material_review_path(review.material, review),
+                    method: :delete,
+                    data: { turbo_confirm: "この評価を削除しますか？" },
+                    class: "text-sm text-red-600 hover:text-red-800 bg-transparent border-0 p-0 cursor-pointer" %>
+    </div>
+  <% end %>
 </div>

--- a/app/views/reviews/edit.html.erb
+++ b/app/views/reviews/edit.html.erb
@@ -1,0 +1,10 @@
+<div class="container mx-auto px-4 py-8 max-w-4xl bg-white">
+  <h1 class="text-2xl font-bold text-gray-900 mb-6">評価を編集</h1>
+
+  <%= render 'reviews/form', material: @material, review: @review %>
+
+  <div class="mt-6">
+    <%= link_to "教材ページに戻る", material_path(@material),
+                class: "inline-flex items-center px-6 py-3 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 transition-colors" %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
   root "materials#index"
   resource :profile, only: [ :show, :edit, :update ]
   resources :materials, only: [ :index, :new, :create, :show ] do
-    resources :reviews, only: [ :create ]
+    resources :reviews, only: [ :create, :edit, :update, :destroy ]
   end
   # resources :materials, only: %i[new create show]
 end

--- a/spec/requests/materials_spec.rb
+++ b/spec/requests/materials_spec.rb
@@ -51,6 +51,55 @@ RSpec.describe "Materials", type: :request do
       get material_path(id: nonexistent_id)
       expect(response).to have_http_status(:not_found)
     end
+
+    # レビュー一覧（_item）の編集/削除コントロールが、閲覧者の状態で出し分けされるか
+    describe "レビューの編集/削除コントロールの表示（_item）" do
+      let(:owner) { create(:user) }                                  # レビューの所有者
+      let!(:review) { create(:review, material: material, user: owner) }
+      # 削除ボタンは button_to の turbo_confirm 文言で判定（パスは編集リンクの部分文字列になり誤判定するため）
+      let(:delete_button_text) { "この評価を削除しますか？" }
+
+      context "所有者がログインしているとき" do
+        before { sign_in owner }
+
+        it "編集リンクが表示される" do
+          get material_path(material)
+          expect(response.body).to include(edit_material_review_path(material, review))
+        end
+
+        it "削除ボタンが表示される" do
+          get material_path(material)
+          expect(response.body).to include(delete_button_text)
+        end
+      end
+
+      context "非所有者がログインしているとき" do
+        let(:viewer) { create(:user) }
+        before { sign_in viewer }
+
+        it "編集リンクが表示されない" do
+          get material_path(material)
+          expect(response.body).not_to include(edit_material_review_path(material, review))
+        end
+
+        it "削除ボタンが表示されない" do
+          get material_path(material)
+          expect(response.body).not_to include(delete_button_text)
+        end
+      end
+
+      context "未ログインのとき" do
+        it "編集リンクが表示されない" do
+          get material_path(material)
+          expect(response.body).not_to include(edit_material_review_path(material, review))
+        end
+
+        it "削除ボタンが表示されない" do
+          get material_path(material)
+          expect(response.body).not_to include(delete_button_text)
+        end
+      end
+    end
   end
 
   describe "GET /materials/new" do

--- a/spec/requests/reviews_spec.rb
+++ b/spec/requests/reviews_spec.rb
@@ -181,4 +181,150 @@ RSpec.describe "Reviews", type: :request do
       end
     end
   end
+
+  # ===== edit / update / destroy（レビューの編集・削除）=====
+
+  describe "GET /materials/:material_id/reviews/:id/edit" do
+    context "自分のレビュー" do
+      let(:review) { create(:review, material: material, user: user) }
+      before { sign_in user }
+
+      it "200 で編集フォームが開ける" do
+        get edit_material_review_path(material, review)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "既存 topic がカンマ区切りでフォームに初期表示される" do
+        review.topics = [ Topic.find_or_create_from_input("ruby"), Topic.find_or_create_from_input("rails") ]
+        get edit_material_review_path(material, review)
+        expect(response.body).to match(/ruby, rails|rails, ruby/)
+      end
+    end
+
+    context "他人のレビュー" do
+      before { sign_in user }
+
+      it "404 を返す（他人のレビューは編集フォームを開けない）" do
+        other_user = create(:user)
+        other_user_review = create(:review, material: material, user: other_user)
+        get edit_material_review_path(material, other_user_review)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "未ログイン" do
+      it "ログイン画面にリダイレクトする" do
+        review = create(:review, material: material, user: user)
+        get edit_material_review_path(material, review)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe "PATCH /materials/:material_id/reviews/:id" do
+    let(:review) { create(:review, material: material, user: user, comment: "編集前のコメント") }
+
+    context "自分のレビュー（正常）" do
+      before { sign_in user }
+
+      it "レベル・難易度・コメントを更新できる" do
+        patch material_review_path(material, review), params: {
+          review: { start_level: "advanced_level", difficulty_rating: "very_difficult", comment: "編集後のコメント" }
+        }
+        review.reload
+        expect(review.start_level).to eq("advanced_level")
+        expect(review.difficulty_rating).to eq("very_difficult")
+        expect(review.comment).to eq("編集後のコメント")
+      end
+
+      it "topic の付け替えが反映される" do
+        review.topics = [ Topic.find_or_create_from_input("ruby") ]
+        patch material_review_path(material, review), params: {
+          review: { start_level: "basic_level", difficulty_rating: "just_right", topic_names: "rails, docker" }
+        }
+        expect(review.reload.topics.pluck(:name)).to contain_exactly("rails", "docker")
+      end
+
+      it "更新成功後は教材ページにリダイレクトし notice が立つ" do
+        patch material_review_path(material, review), params: {
+          review: { start_level: "basic_level", difficulty_rating: "just_right" }
+        }
+        expect(response).to redirect_to(material_path(material))
+        expect(flash[:notice]).to include("評価を更新しました")
+      end
+    end
+
+    context "自分のレビュー（不正）" do
+      before { sign_in user }
+
+      it "更新失敗時は 422 で edit が再描画される" do
+        patch material_review_path(material, review), params: {
+          review: { start_level: "", difficulty_rating: "just_right" }
+        }
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.body).to include("評価を編集")
+      end
+    end
+
+    context "他人のレビュー" do
+      before { sign_in user }
+
+      it "404 を返し、内容が変わらない" do
+        other_user = create(:user)
+        other_user_review = create(:review, material: material, user: other_user, comment: "他人のコメント")
+        patch material_review_path(material, other_user_review), params: {
+          review: { start_level: "advanced_level", difficulty_rating: "very_difficult", comment: "乗っ取り" }
+        }
+        expect(response).to have_http_status(:not_found)
+        expect(other_user_review.reload.comment).to eq("他人のコメント")
+      end
+    end
+
+    context "未ログイン" do
+      it "ログイン画面にリダイレクトする" do
+        patch material_review_path(material, review), params: valid_params
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe "DELETE /materials/:material_id/reviews/:id" do
+    context "自分のレビュー" do
+      let!(:review) { create(:review, material: material, user: user) }
+      before { sign_in user }
+
+      it "削除でき、Review が 1 件減る" do
+        expect {
+          delete material_review_path(material, review)
+        }.to change(Review, :count).by(-1)
+      end
+
+      it "削除後は教材ページにリダイレクトし、成功メッセージ(notice)がセットされる" do
+        delete material_review_path(material, review)
+        expect(response).to redirect_to(material_path(material))
+        expect(flash[:notice]).to include("評価を削除しました")
+      end
+    end
+
+    context "他人のレビュー" do
+      before { sign_in user }
+
+      it "404 を返し、削除されない" do
+        other_user = create(:user)
+        other_user_review = create(:review, material: material, user: other_user)
+        expect {
+          delete material_review_path(material, other_user_review)
+        }.not_to change(Review, :count)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "未ログイン" do
+      it "ログイン画面にリダイレクトする" do
+        review = create(:review, material: material, user: user)
+        delete material_review_path(material, review)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 概要
レビュー（Review）の編集・削除機能（edit / update / destroy）を追加する。これまでレビューは作成のみで、
投稿後に自分のレビューを修正・削除できなかった。

## 変更内容
- ルーティングに reviews の edit / update / destroy を追加
- ReviewsController に edit / update / destroy を実装。`before_action :set_own_review`
  （`current_user.reviews.find`）で自分のレビューに限定
- update は成功時に `assign_topics` で topic を付け替え教材ページへ redirect、失敗時は 422 で edit 再描画
- ビュー：`reviews/edit.html.erb` 新規、`_form` の submit ラベルを `persisted?` で出し分け、
  `_item` に所有者限定の編集リンク・削除ボタン（button_to + turbo_confirm）
- request spec を追加（edit/update/destroy の正常・認可・未ログイン、_item の編集/削除コントロール表示）

## 影響範囲
- レビュー機能（作成のみ → 編集・削除も可能に）
- 教材詳細ページ（materials#show）のレビュー一覧に、自分のレビューの編集/削除コントロールが追加表示
- create / new・既存表示は変更なし（インラインフォーム据え置き）

## 確認方法
1. ログインして、自分が評価した教材の詳細ページを開く
2. 自分のレビューの「編集」をクリック
3. レベル・難易度・コメント・分野を変更し「評価を更新」→ 教材ページに戻り「評価を更新しました」と反映を確認
4. 分野欄を空にして更新 → topic が外れることを確認
5. 「削除」→ 確認ダイアログ → 削除され「評価を削除しました」を確認
6. （認可）他人のレビューの編集 URL（`/materials/:material_id/reviews/:id/edit`）に直接アクセス → 404 を確認

## スクリーンショット
特になし

## 補足事項
- 認可は `current_user.reviews.find` のスコープで「自分のもの以外は RecordNotFound → 404」を実現。
- `_item` の編集/削除コントロール表示は request spec で所有者/非所有者/未ログインの 3 状態を検証（見た目・操作は system/e2e に後回し）。

## 関連Issue
Closes #227