### PR TITLE
docs: CLAUDE.md をレビュー CRUD 追加後の現状に更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ docker compose exec web bundle exec brakeman                   # セキュリテ
 
 - **User**（Devise）— display_name（最大 50 文字）を持つ
 - **Material** — title（最大 100 文字）、URL（http/https のみ）、description（最大 5000 文字）
-- **Review** — User → Material の評価。`start_level`（学習開始レベル 1〜5）と `difficulty_rating`（難易度評価 1〜5）を持つ enum。同一ユーザーと教材の組み合わせは一意制約あり。`has_many :topics, through: :review_topics` で分野（topic）を多対多で持ち、フォーム入力用の仮想属性 `topic_names`（カンマ区切り文字列）を持つ
+- **Review** — User → Material の評価。`start_level`（学習開始レベル 1〜5）と `difficulty_rating`（難易度評価 1〜5）を持つ enum。同一ユーザーと教材の組み合わせは一意制約あり。`has_many :topics, through: :review_topics` で分野（topic）を多対多で持ち、フォーム入力用の仮想属性 `topic_names`（カンマ区切り文字列）を持つ。レビューの編集・削除は作成者本人のみ可（`ReviewsController#set_own_review` が `current_user.reviews.find` で自分のレビューに限定し、他人の id は `RecordNotFound`＝404）
 - **Topic** — 分野マスタ。name（最大 50 文字・一意）。`find_or_create_from_input` で入力を strip + downcase 正規化して引き当て / 新規作成
 - **ReviewTopic** — Review と Topic の中間テーブル。`[review_id, topic_id]` の複合一意制約
 
@@ -75,7 +75,7 @@ docker compose exec web bundle exec brakeman                   # セキュリテ
 root → materials#index
 resource  :profile,   only: [:show, :edit, :update]            # 単数 resource
 resources :materials, only: [:index, :new, :create, :show]     # 検索: Ransack（タイトル部分一致）
-  resources :reviews, only: [:create]                          # materials にネスト
+  resources :reviews, only: [:create, :edit, :update, :destroy] # materials にネスト。編集/削除は所有者のみ
 ```
 
 ### フロントエンド


### PR DESCRIPTION
## 概要
CLAUDE.md の記述を現状（PR #228 でレビューの edit/update/destroy を追加）に合わせて更新する。
ルーティング節が create のみのままだったため、実際のアクション構成と認可の振る舞いを反映する。

## 変更内容
- ルーティング節の reviews を `[:create, :edit, :update, :destroy]` に修正（編集/削除は所有者のみ）
- Review モデルの説明に「編集・削除は作成者本人のみ可（`set_own_review` / `current_user.reviews.find` / 他人は 404）」を追記

## 影響範囲
- ドキュメントのみ（コード・テストへの影響なし）

## 確認方法
1. CLAUDE.md のルーティング節が `config/routes.rb` の reviews アクションと一致することを確認
2. レビューの認可（他人のレビュー編集 URL 直打ち → 404）の記述が実装と一致することを確認

## スクリーンショット
（なし・ドキュメント変更）

## 補足事項
特になし

## 関連Issue
Closes #229 